### PR TITLE
feat: implement core pages and layout

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["next/core-web-vitals", "prettier"]
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules
+.next
+.env

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,86 @@
-# Admin-Dashboard-MVP
-Next.js Admin Dashboard MVP
+# Next.js Admin Dashboard Template
+
+Modern admin dashboard template built with the App Router in Next.js, using TypeScript and Tailwind CSS.
+
+## Tech Stack
+
+- **Framework:** Next.js (App Router)
+- **Language:** TypeScript
+- **Styling:** Tailwind CSS
+- **UI Kit:** [shadcn/ui](https://ui.shadcn.com)
+- **Forms:** React Hook Form + Zod
+- **Tables:** TanStack Table
+- **Charts:** Chart.js via react-chartjs-2
+- **Theming:** next-themes (light/dark)
+- **State (lightweight):** React Context (optionally Zustand)
+- **Mock API:** Next.js Route Handlers and/or MSW (dev only)
+- **Icons:** lucide-react
+- **Quality:** ESLint + Prettier
+
+## Principles
+
+- MVP scope only (6–8 screens, 10–15 atoms/molecules)
+- Shipping > Perfection. Batch updates quarterly.
+- Everything documented. 10-minute time-to-value for buyer.
+
+## Features (MVP)
+
+- Dashboard with KPI cards, charts and recent activity
+- Users page showcasing sortable tables and pagination
+- Example forms with validation and toast feedback
+- Authentication pages for Login, Register and Forgot Password flows
+- Settings page with profile fields and theme toggle
+- Reusable components such as Sidebar, Header, Breadcrumbs, DataTable, ConfirmModal and Toasts
+- Mock API routes for quick integration
+
+## Getting Started
+
+```bash
+npm install
+npm run dev
+```
+
+> The template ships with mock API routes under `app/api/*`. Replace them with your own backend as needed.
+
+## Project Structure
+
+```
+root/
+  app/
+    layout.tsx
+    page.tsx
+    (auth)/
+      layout.tsx
+      login/page.tsx
+      register/page.tsx
+      forgot-password/page.tsx
+    dashboard/page.tsx
+    users/page.tsx
+    forms/page.tsx
+    settings/page.tsx
+    api/
+      users/route.ts
+      stats/route.ts
+      auth/route.ts
+  components/
+    layout/
+    ui/
+    data-table/
+    charts/
+    feedback/
+    common/
+  contexts/
+  lib/
+  mocks/
+  public/
+  styles/
+  tailwind.config.js
+  next.config.js
+  tsconfig.json
+  README.md
+  LICENSE
+```
+
+## License
+
+Released under the MIT License.

--- a/app/(auth)/forgot-password/page.tsx
+++ b/app/(auth)/forgot-password/page.tsx
@@ -1,0 +1,34 @@
+'use client'
+import { useRouter } from 'next/navigation'
+import { useForm } from 'react-hook-form'
+import { z } from 'zod'
+import { zodResolver } from '@hookform/resolvers/zod'
+import { Button } from '@/components/ui/Button'
+import { Input } from '@/components/ui/Input'
+
+const schema = z.object({ email: z.string().email() })
+
+export default function ForgotPasswordPage() {
+  const router = useRouter()
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+  } = useForm<{ email: string }>({ resolver: zodResolver(schema) })
+
+  const onSubmit = () => {
+    router.push('/dashboard')
+  }
+
+  return (
+    <form onSubmit={handleSubmit(onSubmit)} className="w-full max-w-sm space-y-4">
+      <div>
+        <Input type="email" placeholder="Email" {...register('email')} />
+        {errors.email && <p className="mt-1 text-sm text-red-600">{errors.email.message}</p>}
+      </div>
+      <Button type="submit" className="w-full">
+        Send reset link
+      </Button>
+    </form>
+  )
+}

--- a/app/(auth)/layout.tsx
+++ b/app/(auth)/layout.tsx
@@ -1,0 +1,9 @@
+import type { ReactNode } from 'react'
+
+export default function AuthLayout({ children }: { children: ReactNode }) {
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-gray-50 p-4 dark:bg-gray-900">
+      {children}
+    </div>
+  )
+}

--- a/app/(auth)/login/page.tsx
+++ b/app/(auth)/login/page.tsx
@@ -1,0 +1,41 @@
+'use client'
+import { useRouter } from 'next/navigation'
+import { useForm } from 'react-hook-form'
+import { z } from 'zod'
+import { zodResolver } from '@hookform/resolvers/zod'
+import { Button } from '@/components/ui/Button'
+import { Input } from '@/components/ui/Input'
+
+const schema = z.object({
+  email: z.string().email(),
+  password: z.string().min(1),
+})
+
+export default function LoginPage() {
+  const router = useRouter()
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+  } = useForm<{ email: string; password: string }>({ resolver: zodResolver(schema) })
+
+  const onSubmit = () => {
+    router.push('/dashboard')
+  }
+
+  return (
+    <form onSubmit={handleSubmit(onSubmit)} className="w-full max-w-sm space-y-4">
+      <div>
+        <Input type="email" placeholder="Email" {...register('email')} />
+        {errors.email && <p className="mt-1 text-sm text-red-600">{errors.email.message}</p>}
+      </div>
+      <div>
+        <Input type="password" placeholder="Password" {...register('password')} />
+        {errors.password && <p className="mt-1 text-sm text-red-600">{errors.password.message}</p>}
+      </div>
+      <Button type="submit" className="w-full">
+        Login
+      </Button>
+    </form>
+  )
+}

--- a/app/(auth)/register/page.tsx
+++ b/app/(auth)/register/page.tsx
@@ -1,0 +1,46 @@
+'use client'
+import { useRouter } from 'next/navigation'
+import { useForm } from 'react-hook-form'
+import { z } from 'zod'
+import { zodResolver } from '@hookform/resolvers/zod'
+import { Button } from '@/components/ui/Button'
+import { Input } from '@/components/ui/Input'
+
+const schema = z.object({
+  name: z.string().min(1),
+  email: z.string().email(),
+  password: z.string().min(6),
+})
+
+export default function RegisterPage() {
+  const router = useRouter()
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+  } = useForm<{ name: string; email: string; password: string }>({ resolver: zodResolver(schema) })
+
+  const onSubmit = () => {
+    router.push('/dashboard')
+  }
+
+  return (
+    <form onSubmit={handleSubmit(onSubmit)} className="w-full max-w-sm space-y-4">
+      <div>
+        <Input placeholder="Name" {...register('name')} />
+        {errors.name && <p className="mt-1 text-sm text-red-600">{errors.name.message}</p>}
+      </div>
+      <div>
+        <Input type="email" placeholder="Email" {...register('email')} />
+        {errors.email && <p className="mt-1 text-sm text-red-600">{errors.email.message}</p>}
+      </div>
+      <div>
+        <Input type="password" placeholder="Password" {...register('password')} />
+        {errors.password && <p className="mt-1 text-sm text-red-600">{errors.password.message}</p>}
+      </div>
+      <Button type="submit" className="w-full">
+        Register
+      </Button>
+    </form>
+  )
+}

--- a/app/api/auth/route.ts
+++ b/app/api/auth/route.ts
@@ -1,0 +1,6 @@
+import { NextResponse } from 'next/server'
+
+export async function POST(req: Request) {
+  const body = await req.json()
+  return NextResponse.json({ ok: true, user: { id: '1', ...body } })
+}

--- a/app/api/stats/route.ts
+++ b/app/api/stats/route.ts
@@ -1,0 +1,6 @@
+import { NextResponse } from 'next/server'
+import data from '@/mocks/data/stats.json'
+
+export async function GET() {
+  return NextResponse.json(data)
+}

--- a/app/api/users/route.ts
+++ b/app/api/users/route.ts
@@ -1,0 +1,11 @@
+import { NextResponse } from 'next/server'
+import data from '@/mocks/data/users.json'
+
+export async function GET() {
+  return NextResponse.json(data)
+}
+
+export async function POST(req: Request) {
+  const body = await req.json()
+  return NextResponse.json({ ok: true, user: { id: crypto.randomUUID(), ...body } }, { status: 201 })
+}

--- a/app/blank/page.tsx
+++ b/app/blank/page.tsx
@@ -1,0 +1,3 @@
+export default function BlankPage() {
+  return <div>Blank Page</div>
+}

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -1,0 +1,49 @@
+'use client'
+import useSWR from 'swr'
+import LineChart from '@/components/charts/LineChart'
+import { fetcher } from '@/lib/fetcher'
+import { DashboardStats, User } from '@/lib/types'
+import DataTable from '@/components/data-table/DataTable'
+import type { ColumnDef } from '@tanstack/react-table'
+import EmptyState from '@/components/common/EmptyState'
+
+export default function DashboardPage() {
+  const { data: stats } = useSWR<DashboardStats>('/api/stats', fetcher)
+  const { data: users } = useSWR<User[]>('/api/users', fetcher)
+
+  const columns: ColumnDef<User>[] = [
+    { header: 'Name', accessorKey: 'name' },
+    { header: 'Email', accessorKey: 'email' },
+    { header: 'Role', accessorKey: 'role' },
+  ]
+
+  return (
+    <div className="space-y-6">
+      {stats ? (
+        <div className="grid gap-4 sm:grid-cols-3">
+          <div className="rounded bg-white p-4 shadow dark:bg-gray-800">
+            <p className="text-sm text-gray-500">Users</p>
+            <p className="text-2xl font-semibold">{stats.users}</p>
+          </div>
+          <div className="rounded bg-white p-4 shadow dark:bg-gray-800">
+            <p className="text-sm text-gray-500">Revenue</p>
+            <p className="text-2xl font-semibold">${stats.revenue}</p>
+          </div>
+          <div className="rounded bg-white p-4 shadow dark:bg-gray-800">
+            <p className="text-sm text-gray-500">Growth</p>
+            <p className="text-2xl font-semibold">{stats.growthPct}%</p>
+          </div>
+        </div>
+      ) : (
+        <EmptyState />
+      )}
+
+      {stats && <LineChart data={stats.series} />}
+
+      <div>
+        <h2 className="mb-2 text-lg font-semibold">Recent Users</h2>
+        {users ? <DataTable columns={columns} data={users.slice(0, 5)} /> : <EmptyState />}
+      </div>
+    </div>
+  )
+}

--- a/app/error.tsx
+++ b/app/error.tsx
@@ -1,0 +1,12 @@
+'use client'
+export default function Error({ error, reset }: { error: Error; reset: () => void }) {
+  return (
+    <div className="p-8">
+      <h1 className="mb-4 text-2xl font-bold">Something went wrong</h1>
+      <p className="mb-4 text-sm text-gray-600">{error.message}</p>
+      <button className="rounded border px-4 py-2" onClick={reset}>
+        Try again
+      </button>
+    </div>
+  )
+}

--- a/app/forms/page.tsx
+++ b/app/forms/page.tsx
@@ -1,0 +1,50 @@
+'use client'
+import { useForm } from 'react-hook-form'
+import { zodResolver } from '@hookform/resolvers/zod'
+import { userSchema, UserFormValues } from '@/lib/validators'
+import { Button } from '@/components/ui/Button'
+import { Input } from '@/components/ui/Input'
+import { Select } from '@/components/ui/Select'
+import { Checkbox } from '@/components/ui/Checkbox'
+import { toast } from 'sonner'
+
+export default function FormsPage() {
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+  } = useForm<UserFormValues>({
+    resolver: zodResolver(userSchema),
+    defaultValues: { active: true, role: 'viewer' },
+  })
+
+  const onSubmit = (data: UserFormValues) => {
+    toast.success('Saved')
+  }
+
+  return (
+    <form onSubmit={handleSubmit(onSubmit)} className="max-w-md space-y-4">
+      <div>
+        <Input placeholder="Name" {...register('name')} />
+        {errors.name && <p className="text-sm text-red-600">{errors.name.message}</p>}
+      </div>
+      <div>
+        <Input type="email" placeholder="Email" {...register('email')} />
+        {errors.email && <p className="text-sm text-red-600">{errors.email.message}</p>}
+      </div>
+      <div>
+        <Select {...register('role')}>
+          <option value="admin">Admin</option>
+          <option value="editor">Editor</option>
+          <option value="viewer">Viewer</option>
+        </Select>
+        {errors.role && <p className="text-sm text-red-600">{errors.role.message}</p>}
+      </div>
+      <div className="flex items-center gap-2">
+        <Checkbox {...register('active')} />
+        <span>Active</span>
+      </div>
+      <Button type="submit">Save</Button>
+    </form>
+  )
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,0 +1,33 @@
+import './globals.css'
+import type { ReactNode } from 'react'
+import Sidebar from '@/components/layout/Sidebar'
+import Header from '@/components/layout/Header'
+import { ThemeProvider } from '@/contexts/ThemeProvider'
+import { SidebarProvider } from '@/contexts/SidebarProvider'
+import ToasterProvider from '@/components/feedback/ToasterProvider'
+
+export const metadata = {
+  title: 'Admin Dashboard',
+  description: 'Admin dashboard template',
+}
+
+export default function RootLayout({ children }: { children: ReactNode }) {
+  return (
+    <html lang="en" suppressHydrationWarning>
+      <body className="min-h-screen bg-gray-50 text-gray-900 dark:bg-gray-900 dark:text-gray-100">
+        <ThemeProvider>
+          <SidebarProvider>
+            <ToasterProvider />
+            <div className="flex min-h-screen">
+              <Sidebar />
+              <div className="flex flex-1 flex-col">
+                <Header />
+                <main className="flex-1 p-4">{children}</main>
+              </div>
+            </div>
+          </SidebarProvider>
+        </ThemeProvider>
+      </body>
+    </html>
+  )
+}

--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -1,0 +1,8 @@
+export default function NotFound() {
+  return (
+    <div className="p-8">
+      <h1 className="mb-2 text-2xl font-bold">404 - Page Not Found</h1>
+      <p>The page you are looking for does not exist.</p>
+    </div>
+  )
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,0 +1,5 @@
+import { redirect } from 'next/navigation'
+
+export default function Home() {
+  redirect('/dashboard')
+}

--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -1,0 +1,48 @@
+'use client'
+import { useForm } from 'react-hook-form'
+import { z } from 'zod'
+import { zodResolver } from '@hookform/resolvers/zod'
+import { Button } from '@/components/ui/Button'
+import { Input } from '@/components/ui/Input'
+import { Switch } from '@/components/ui/Switch'
+import { useTheme } from 'next-themes'
+import { useState } from 'react'
+import { toast } from 'sonner'
+
+const schema = z.object({
+  name: z.string().min(1),
+  email: z.string().email(),
+})
+
+export default function SettingsPage() {
+  const { theme, setTheme } = useTheme()
+  const [dark, setDark] = useState(theme === 'dark')
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+  } = useForm<{ name: string; email: string }>({ resolver: zodResolver(schema) })
+
+  const onSubmit = () => {
+    setTheme(dark ? 'dark' : 'light')
+    toast.success('Settings saved')
+  }
+
+  return (
+    <form onSubmit={handleSubmit(onSubmit)} className="max-w-md space-y-4">
+      <div>
+        <Input placeholder="Name" {...register('name')} />
+        {errors.name && <p className="text-sm text-red-600">{errors.name.message}</p>}
+      </div>
+      <div>
+        <Input type="email" placeholder="Email" {...register('email')} />
+        {errors.email && <p className="text-sm text-red-600">{errors.email.message}</p>}
+      </div>
+      <div className="flex items-center gap-2">
+        <Switch checked={dark} onChange={(e) => setDark(e.target.checked)} />
+        <span>Dark Mode</span>
+      </div>
+      <Button type="submit">Save</Button>
+    </form>
+  )
+}

--- a/app/users/page.tsx
+++ b/app/users/page.tsx
@@ -1,0 +1,60 @@
+'use client'
+import useSWR from 'swr'
+import { fetcher } from '@/lib/fetcher'
+import DataTable from '@/components/data-table/DataTable'
+import type { ColumnDef } from '@tanstack/react-table'
+import { User } from '@/lib/types'
+import { Button } from '@/components/ui/Button'
+import { useState } from 'react'
+import ConfirmModal from '@/components/common/ConfirmModal'
+import EmptyState from '@/components/common/EmptyState'
+
+export default function UsersPage() {
+  const { data, mutate } = useSWR<User[]>('/api/users', fetcher)
+  const [deleteId, setDeleteId] = useState<string | null>(null)
+
+  const columns: ColumnDef<User>[] = [
+    { header: 'Name', accessorKey: 'name' },
+    { header: 'Email', accessorKey: 'email' },
+    { header: 'Role', accessorKey: 'role' },
+    { header: 'Active', accessorKey: 'active', cell: ({ row }) => (row.original.active ? 'Yes' : 'No') },
+    {
+      header: 'Actions',
+      cell: ({ row }) => (
+        <div className="flex gap-2">
+          <Button type="button" onClick={() => alert('Edit ' + row.original.id)} className="px-2 py-1">
+            Edit
+          </Button>
+          <Button
+            type="button"
+            onClick={() => setDeleteId(row.original.id)}
+            className="bg-red-600 px-2 py-1"
+          >
+            Delete
+          </Button>
+        </div>
+      ),
+    },
+  ]
+
+  const handleDelete = () => {
+    if (data && deleteId) {
+      mutate(data.filter((u) => u.id !== deleteId), false)
+    }
+    setDeleteId(null)
+  }
+
+  if (!data) return <EmptyState />
+
+  return (
+    <div>
+      <DataTable columns={columns} data={data} searchKey="name" />
+      <ConfirmModal
+        open={!!deleteId}
+        title="Delete user?"
+        onConfirm={handleDelete}
+        onCancel={() => setDeleteId(null)}
+      />
+    </div>
+  )
+}

--- a/components/charts/LineChart.tsx
+++ b/components/charts/LineChart.tsx
@@ -1,0 +1,31 @@
+'use client'
+import {
+  Chart as ChartJS,
+  CategoryScale,
+  LinearScale,
+  PointElement,
+  LineElement,
+  Tooltip,
+  Legend,
+} from 'chart.js'
+import { Line } from 'react-chartjs-2'
+
+type Series = Array<{ date: string; value: number }>
+
+ChartJS.register(CategoryScale, LinearScale, PointElement, LineElement, Tooltip, Legend)
+
+export default function LineChart({ data }: { data: Series }) {
+  const chartData = {
+    labels: data.map((d) => d.date),
+    datasets: [
+      {
+        label: 'Value',
+        data: data.map((d) => d.value),
+        borderColor: 'rgb(37, 99, 235)',
+        backgroundColor: 'rgba(37, 99, 235, 0.5)',
+      },
+    ],
+  }
+
+  return <Line data={chartData} />
+}

--- a/components/common/AvatarMenu.tsx
+++ b/components/common/AvatarMenu.tsx
@@ -1,0 +1,36 @@
+'use client'
+import { useState } from 'react'
+import Link from 'next/link'
+
+export default function AvatarMenu() {
+  const [open, setOpen] = useState(false)
+  return (
+    <div className="relative">
+      <button
+        className="h-8 w-8 rounded-full bg-gray-300"
+        onClick={() => setOpen((o) => !o)}
+        aria-label="Toggle menu"
+      />
+      {open && (
+        <div className="absolute right-0 mt-2 w-40 rounded border bg-white shadow dark:bg-gray-800">
+          <Link
+            href="/settings"
+            className="block px-3 py-2 text-sm hover:bg-gray-100 dark:hover:bg-gray-700"
+            onClick={() => setOpen(false)}
+          >
+            Settings
+          </Link>
+          <button
+            className="block w-full px-3 py-2 text-left text-sm hover:bg-gray-100 dark:hover:bg-gray-700"
+            onClick={() => {
+              setOpen(false)
+              alert('Logged out')
+            }}
+          >
+            Logout
+          </button>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/components/common/ConfirmModal.tsx
+++ b/components/common/ConfirmModal.tsx
@@ -1,0 +1,29 @@
+'use client'
+
+type Props = {
+  open: boolean
+  title: string
+  description?: string
+  onConfirm: () => void
+  onCancel: () => void
+}
+
+export default function ConfirmModal({ open, title, description, onConfirm, onCancel }: Props) {
+  if (!open) return null
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
+      <div className="w-full max-w-sm rounded bg-white p-6 shadow dark:bg-gray-800">
+        <h2 className="mb-2 text-lg font-semibold">{title}</h2>
+        {description && <p className="mb-4 text-sm text-gray-600 dark:text-gray-300">{description}</p>}
+        <div className="flex justify-end gap-2">
+          <button className="rounded border px-3 py-1" onClick={onCancel}>
+            Cancel
+          </button>
+          <button className="rounded bg-red-600 px-3 py-1 text-white" onClick={onConfirm}>
+            Confirm
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/components/common/EmptyState.tsx
+++ b/components/common/EmptyState.tsx
@@ -1,0 +1,8 @@
+export default function EmptyState({ title = 'No results', message = 'No records found' }: { title?: string; message?: string }) {
+  return (
+    <div className="py-10 text-center text-sm text-gray-500">
+      <p className="font-medium">{title}</p>
+      <p>{message}</p>
+    </div>
+  )
+}

--- a/components/data-table/DataTable.tsx
+++ b/components/data-table/DataTable.tsx
@@ -1,0 +1,88 @@
+'use client'
+import { useState } from 'react'
+import {
+  ColumnDef,
+  flexRender,
+  getCoreRowModel,
+  getFilteredRowModel,
+  getPaginationRowModel,
+  getSortedRowModel,
+  useReactTable,
+} from '@tanstack/react-table'
+import { Input } from '../ui/Input'
+import Pagination from './Pagination'
+
+type DataTableProps<TData> = {
+  columns: ColumnDef<TData, any>[]
+  data: TData[]
+  searchKey?: string
+}
+
+export default function DataTable<TData>({ columns, data, searchKey }: DataTableProps<TData>) {
+  const [filter, setFilter] = useState('')
+  const table = useReactTable({
+    data,
+    columns,
+    state: {
+      globalFilter: filter,
+    },
+    onGlobalFilterChange: setFilter,
+    getCoreRowModel: getCoreRowModel(),
+    getSortedRowModel: getSortedRowModel(),
+    getFilteredRowModel: getFilteredRowModel(),
+    getPaginationRowModel: getPaginationRowModel(),
+  })
+
+  return (
+    <div>
+      {searchKey && (
+        <div className="mb-2">
+          <Input
+            placeholder="Search..."
+            value={filter}
+            onChange={(e) => setFilter(e.target.value)}
+          />
+        </div>
+      )}
+      <div className="overflow-x-auto">
+        <table className="min-w-full border text-sm">
+          <thead>
+            {table.getHeaderGroups().map((headerGroup) => (
+              <tr key={headerGroup.id}>
+                {headerGroup.headers.map((header) => (
+                  <th
+                    key={header.id}
+                    onClick={header.column.getToggleSortingHandler()}
+                    className="cursor-pointer border-b bg-gray-50 px-2 py-1 text-left dark:bg-gray-800"
+                  >
+                    {flexRender(header.column.columnDef.header, header.getContext())}
+                  </th>
+                ))}
+              </tr>
+            ))}
+          </thead>
+          <tbody>
+            {table.getRowModel().rows.length ? (
+              table.getRowModel().rows.map((row) => (
+                <tr key={row.id} className="border-b last:border-b-0">
+                  {row.getVisibleCells().map((cell) => (
+                    <td key={cell.id} className="px-2 py-1">
+                      {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                    </td>
+                  ))}
+                </tr>
+              ))
+            ) : (
+              <tr>
+                <td colSpan={columns.length} className="p-4">
+                  No results.
+                </td>
+              </tr>
+            )}
+          </tbody>
+        </table>
+      </div>
+      <Pagination table={table} />
+    </div>
+  )
+}

--- a/components/data-table/Pagination.tsx
+++ b/components/data-table/Pagination.tsx
@@ -1,0 +1,26 @@
+'use client'
+import { Table } from '@tanstack/react-table'
+
+export default function Pagination<T>({ table }: { table: Table<T> }) {
+  return (
+    <div className="mt-4 flex items-center gap-2">
+      <button
+        className="rounded border px-2 py-1"
+        onClick={() => table.previousPage()}
+        disabled={!table.getCanPreviousPage()}
+      >
+        Prev
+      </button>
+      <span>
+        Page {table.getState().pagination.pageIndex + 1} of {table.getPageCount()}
+      </span>
+      <button
+        className="rounded border px-2 py-1"
+        onClick={() => table.nextPage()}
+        disabled={!table.getCanNextPage()}
+      >
+        Next
+      </button>
+    </div>
+  )
+}

--- a/components/feedback/ToasterProvider.tsx
+++ b/components/feedback/ToasterProvider.tsx
@@ -1,0 +1,6 @@
+'use client'
+import { Toaster } from 'sonner'
+
+export default function ToasterProvider() {
+  return <Toaster position="top-right" richColors />
+}

--- a/components/layout/Breadcrumbs.tsx
+++ b/components/layout/Breadcrumbs.tsx
@@ -1,0 +1,34 @@
+'use client'
+import Link from 'next/link'
+import { usePathname } from 'next/navigation'
+
+export default function Breadcrumbs() {
+  const pathname = usePathname()
+  const segments = pathname.split('/').filter(Boolean)
+
+  return (
+    <nav className="text-sm text-gray-500">
+      <ol className="flex items-center gap-1">
+        <li>
+          <Link href="/dashboard" className="hover:underline">
+            Home
+          </Link>
+        </li>
+        {segments.map((segment, idx) => {
+          const href = '/' + segments.slice(0, idx + 1).join('/')
+          return (
+            <li key={href} className="flex items-center gap-1">
+              <span>/</span>
+              <Link
+                href={href}
+                className={idx === segments.length - 1 ? 'text-gray-700 dark:text-gray-300' : 'hover:underline'}
+              >
+                {segment}
+              </Link>
+            </li>
+          )
+        })}
+      </ol>
+    </nav>
+  )
+}

--- a/components/layout/Header.tsx
+++ b/components/layout/Header.tsx
@@ -1,0 +1,28 @@
+'use client'
+import { Menu, Moon, Sun } from 'lucide-react'
+import { useSidebar } from '@/contexts/SidebarProvider'
+import Breadcrumbs from './Breadcrumbs'
+import AvatarMenu from '../common/AvatarMenu'
+import { useTheme } from 'next-themes'
+
+export default function Header() {
+  const { toggle } = useSidebar()
+  const { theme, setTheme } = useTheme()
+  const isDark = theme === 'dark'
+  return (
+    <header className="flex items-center justify-between border-b bg-white px-4 py-2 dark:bg-gray-900">
+      <div className="flex items-center gap-2">
+        <button className="md:hidden" onClick={toggle} aria-label="Toggle sidebar">
+          <Menu className="h-5 w-5" />
+        </button>
+        <Breadcrumbs />
+      </div>
+      <div className="flex items-center gap-4">
+        <button onClick={() => setTheme(isDark ? 'light' : 'dark')} aria-label="Toggle theme">
+          {isDark ? <Sun className="h-5 w-5" /> : <Moon className="h-5 w-5" />}
+        </button>
+        <AvatarMenu />
+      </div>
+    </header>
+  )
+}

--- a/components/layout/Sidebar.tsx
+++ b/components/layout/Sidebar.tsx
@@ -1,0 +1,37 @@
+'use client'
+import Link from 'next/link'
+import { usePathname } from 'next/navigation'
+import { useSidebar } from '@/contexts/SidebarProvider'
+
+const links = [
+  { href: '/dashboard', label: 'Dashboard' },
+  { href: '/users', label: 'Users' },
+  { href: '/forms', label: 'Forms' },
+  { href: '/settings', label: 'Settings' },
+  { href: '/blank', label: 'Blank' },
+]
+
+export default function Sidebar() {
+  const { isOpen, toggle } = useSidebar()
+  const pathname = usePathname()
+  return (
+    <aside
+      className={`fixed inset-y-0 left-0 z-40 w-64 transform bg-gray-800 p-4 text-white transition-transform md:static md:translate-x-0 ${
+        isOpen ? 'translate-x-0' : '-translate-x-full'
+      }`}
+    >
+      <nav className="space-y-2">
+        {links.map((link) => (
+          <Link
+            key={link.href}
+            href={link.href}
+            className={`block rounded px-2 py-1 hover:bg-gray-700 ${pathname === link.href ? 'bg-gray-700' : ''}`}
+            onClick={() => isOpen && toggle()}
+          >
+            {link.label}
+          </Link>
+        ))}
+      </nav>
+    </aside>
+  )
+}

--- a/components/ui/Button.tsx
+++ b/components/ui/Button.tsx
@@ -1,0 +1,11 @@
+'use client'
+import { ButtonHTMLAttributes } from 'react'
+
+export function Button({ className = '', ...props }: ButtonHTMLAttributes<HTMLButtonElement>) {
+  return (
+    <button
+      className={`inline-flex items-center justify-center rounded bg-blue-600 px-4 py-2 text-white hover:bg-blue-700 disabled:opacity-50 ${className}`}
+      {...props}
+    />
+  )
+}

--- a/components/ui/Checkbox.tsx
+++ b/components/ui/Checkbox.tsx
@@ -1,0 +1,6 @@
+'use client'
+import { InputHTMLAttributes } from 'react'
+
+export function Checkbox({ className = '', ...props }: InputHTMLAttributes<HTMLInputElement>) {
+  return <input type="checkbox" className={`h-4 w-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500 ${className}`} {...props} />
+}

--- a/components/ui/Dialog.tsx
+++ b/components/ui/Dialog.tsx
@@ -1,0 +1,30 @@
+'use client'
+import { ReactNode } from 'react'
+
+type DialogProps = {
+  open: boolean
+  onClose: () => void
+  title?: string
+  children: ReactNode
+}
+
+export function Dialog({ open, onClose, title, children }: DialogProps) {
+  if (!open) return null
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4">
+      <div className="w-full max-w-md rounded bg-white p-4 shadow dark:bg-gray-800">
+        {title && <h2 className="mb-4 text-lg font-semibold">{title}</h2>}
+        {children}
+        <div className="mt-4 flex justify-end">
+          <button
+            className="rounded bg-blue-600 px-4 py-2 text-white hover:bg-blue-700"
+            onClick={onClose}
+          >
+            Close
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/components/ui/DropdownMenu.tsx
+++ b/components/ui/DropdownMenu.tsx
@@ -1,0 +1,23 @@
+'use client'
+import { ReactNode, useState } from 'react'
+
+type DropdownMenuProps = {
+  trigger: ReactNode
+  children: ReactNode
+}
+
+export function DropdownMenu({ trigger, children }: DropdownMenuProps) {
+  const [open, setOpen] = useState(false)
+  return (
+    <div className="relative inline-block text-left">
+      <div onClick={() => setOpen((v) => !v)} className="cursor-pointer">
+        {trigger}
+      </div>
+      {open && (
+        <div className="absolute right-0 z-50 mt-2 w-56 rounded border bg-white shadow dark:bg-gray-800">
+          {children}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/components/ui/Input.tsx
+++ b/components/ui/Input.tsx
@@ -1,0 +1,6 @@
+'use client'
+import { InputHTMLAttributes } from 'react'
+
+export function Input({ className = '', ...props }: InputHTMLAttributes<HTMLInputElement>) {
+  return <input className={`border rounded px-3 py-2 w-full bg-white dark:bg-gray-800 ${className}`} {...props} />
+}

--- a/components/ui/Select.tsx
+++ b/components/ui/Select.tsx
@@ -1,0 +1,6 @@
+'use client'
+import { SelectHTMLAttributes } from 'react'
+
+export function Select({ className = '', ...props }: SelectHTMLAttributes<HTMLSelectElement>) {
+  return <select className={`border rounded px-3 py-2 w-full bg-white dark:bg-gray-800 ${className}`} {...props} />
+}

--- a/components/ui/Skeleton.tsx
+++ b/components/ui/Skeleton.tsx
@@ -1,0 +1,10 @@
+import { HTMLAttributes } from 'react'
+
+export function Skeleton({ className = '', ...props }: HTMLAttributes<HTMLDivElement>) {
+  return (
+    <div
+      className={`animate-pulse rounded-md bg-gray-200 dark:bg-gray-700 ${className}`}
+      {...props}
+    />
+  )
+}

--- a/components/ui/Switch.tsx
+++ b/components/ui/Switch.tsx
@@ -1,0 +1,13 @@
+'use client'
+import { InputHTMLAttributes } from 'react'
+
+export function Switch({ className = '', ...props }: InputHTMLAttributes<HTMLInputElement>) {
+  return (
+    <label className="inline-flex items-center cursor-pointer">
+      <input type="checkbox" className="sr-only" {...props} />
+      <span className={`h-5 w-10 rounded-full bg-gray-300 p-1 transition ${props.checked ? 'bg-blue-600' : ''} ${className}`}>
+        <span className={`block h-4 w-4 rounded-full bg-white shadow-md transform transition ${props.checked ? 'translate-x-5' : ''}`}></span>
+      </span>
+    </label>
+  )
+}

--- a/components/ui/Tabs.tsx
+++ b/components/ui/Tabs.tsx
@@ -1,0 +1,38 @@
+'use client'
+import { ReactNode, useState } from 'react'
+
+type Tab = {
+  id: string
+  label: string
+  content: ReactNode
+}
+
+type TabsProps = {
+  tabs: Tab[]
+}
+
+export function Tabs({ tabs }: TabsProps) {
+  const [active, setActive] = useState(tabs[0]?.id)
+  const current = tabs.find((t) => t.id === active)
+
+  return (
+    <div>
+      <div className="flex border-b border-gray-200 dark:border-gray-700">
+        {tabs.map((tab) => (
+          <button
+            key={tab.id}
+            onClick={() => setActive(tab.id)}
+            className={`-mb-px px-4 py-2 text-sm font-medium hover:text-blue-600 ${
+              active === tab.id
+                ? 'border-b-2 border-blue-600 text-blue-600'
+                : 'border-b-2 border-transparent'
+            }`}
+          >
+            {tab.label}
+          </button>
+        ))}
+      </div>
+      <div className="py-4">{current?.content}</div>
+    </div>
+  )
+}

--- a/components/ui/Toggle.tsx
+++ b/components/ui/Toggle.tsx
@@ -1,0 +1,20 @@
+'use client'
+import { useState, ButtonHTMLAttributes } from 'react'
+
+type ToggleProps = ButtonHTMLAttributes<HTMLButtonElement>
+
+export function Toggle({ className = '', ...props }: ToggleProps) {
+  const [pressed, setPressed] = useState(false)
+  return (
+    <button
+      {...props}
+      onClick={(e) => {
+        setPressed((p) => !p)
+        props.onClick?.(e)
+      }}
+      className={`rounded border px-3 py-2 text-sm ${
+        pressed ? 'bg-blue-600 text-white' : 'bg-white text-gray-700 dark:bg-gray-800 dark:text-gray-200'
+      } ${className}`}
+    />
+  )
+}

--- a/contexts/SidebarProvider.tsx
+++ b/contexts/SidebarProvider.tsx
@@ -1,0 +1,22 @@
+'use client'
+
+import { createContext, useContext, useState, type ReactNode } from 'react'
+
+type SidebarContextValue = {
+  isOpen: boolean
+  toggle: () => void
+}
+
+const SidebarContext = createContext<SidebarContextValue | undefined>(undefined)
+
+export function SidebarProvider({ children }: { children: ReactNode }) {
+  const [isOpen, setIsOpen] = useState(false)
+  const toggle = () => setIsOpen((prev) => !prev)
+  return <SidebarContext.Provider value={{ isOpen, toggle }}>{children}</SidebarContext.Provider>
+}
+
+export function useSidebar() {
+  const context = useContext(SidebarContext)
+  if (!context) throw new Error('useSidebar must be used within SidebarProvider')
+  return context
+}

--- a/contexts/ThemeProvider.tsx
+++ b/contexts/ThemeProvider.tsx
@@ -1,0 +1,12 @@
+'use client'
+
+import { ThemeProvider as NextThemesProvider } from 'next-themes'
+import type { ReactNode } from 'react'
+
+export function ThemeProvider({ children }: { children: ReactNode }) {
+  return (
+    <NextThemesProvider attribute="class" defaultTheme="system" enableSystem>
+      {children}
+    </NextThemesProvider>
+  )
+}

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,12 @@
+const nextJest = require('next/jest')
+
+const createJestConfig = nextJest({
+  dir: './',
+})
+
+const customJestConfig = {
+  testEnvironment: 'jest-environment-jsdom',
+  setupFilesAfterEnv: ['<rootDir>/jest.setup.ts'],
+}
+
+module.exports = createJestConfig(customJestConfig)

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom'

--- a/lib/__tests__/fetcher.test.ts
+++ b/lib/__tests__/fetcher.test.ts
@@ -1,0 +1,26 @@
+import { fetcher } from '../fetcher'
+
+describe('fetcher', () => {
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
+  it('returns json for successful responses', async () => {
+    const data = { ok: true }
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(data),
+    } as any)
+
+    const result = await fetcher<typeof data>('/api')
+    expect(result).toEqual(data)
+  })
+
+  it('throws for error responses', async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: false,
+    } as any)
+
+    await expect(fetcher('/api')).rejects.toThrow('Network response was not ok')
+  })
+})

--- a/lib/__tests__/validators.test.ts
+++ b/lib/__tests__/validators.test.ts
@@ -1,0 +1,23 @@
+import { userSchema } from '../validators'
+
+describe('userSchema', () => {
+  it('validates a correct user', () => {
+    const data = {
+      name: 'Jane Doe',
+      email: 'jane@example.com',
+      role: 'admin',
+      active: true,
+    }
+    expect(userSchema.parse(data)).toMatchObject(data)
+  })
+
+  it('rejects invalid email', () => {
+    const data = {
+      name: 'Jane Doe',
+      email: 'invalid',
+      role: 'admin',
+      active: true,
+    }
+    expect(() => userSchema.parse(data)).toThrow()
+  })
+})

--- a/lib/fetcher.ts
+++ b/lib/fetcher.ts
@@ -1,0 +1,7 @@
+export async function fetcher<T>(input: RequestInfo, init?: RequestInit): Promise<T> {
+  const res = await fetch(input, init)
+  if (!res.ok) {
+    throw new Error('Network response was not ok')
+  }
+  return res.json() as Promise<T>
+}

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -1,0 +1,15 @@
+export type User = {
+  id: string
+  name: string
+  email: string
+  role: 'admin' | 'editor' | 'viewer'
+  active: boolean
+  createdAt: string
+}
+
+export type DashboardStats = {
+  users: number
+  revenue: number
+  growthPct: number
+  series: Array<{ date: string; value: number }>
+}

--- a/lib/validators.ts
+++ b/lib/validators.ts
@@ -1,0 +1,12 @@
+import { z } from 'zod'
+
+export const userSchema = z.object({
+  id: z.string().optional(),
+  name: z.string().min(1),
+  email: z.string().email(),
+  role: z.enum(['admin', 'editor', 'viewer']),
+  active: z.boolean(),
+  createdAt: z.string().optional(),
+})
+
+export type UserFormValues = z.infer<typeof userSchema>

--- a/mocks/data/stats.json
+++ b/mocks/data/stats.json
@@ -1,0 +1,9 @@
+{
+  "users": 100,
+  "revenue": 2000,
+  "growthPct": 5,
+  "series": [
+    { "date": "2024-01-01", "value": 50 },
+    { "date": "2024-02-01", "value": 75 }
+  ]
+}

--- a/mocks/data/users.json
+++ b/mocks/data/users.json
@@ -1,0 +1,10 @@
+[
+  {
+    "id": "1",
+    "name": "Alice",
+    "email": "alice@example.com",
+    "role": "admin",
+    "active": true,
+    "createdAt": "2024-01-01"
+  }
+]

--- a/mocks/handlers.ts
+++ b/mocks/handlers.ts
@@ -1,0 +1,12 @@
+import { rest } from 'msw'
+import users from './data/users.json'
+import stats from './data/stats.json'
+
+export const handlers = [
+  rest.get('/api/users', (_req, res, ctx) => {
+    return res(ctx.status(200), ctx.json(users))
+  }),
+  rest.get('/api/stats', (_req, res, ctx) => {
+    return res(ctx.status(200), ctx.json(stats))
+  }),
+]

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/next.config.js
+++ b/next.config.js
@@ -1,0 +1,4 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {}
+
+module.exports = nextConfig

--- a/package.json
+++ b/package.json
@@ -1,0 +1,42 @@
+{
+  "name": "admin-dashboard-mvp",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint",
+    "test": "jest"
+  },
+  "dependencies": {
+    "@hookform/resolvers": "latest",
+    "@tanstack/react-table": "latest",
+    "chart.js": "latest",
+    "lucide-react": "latest",
+    "next": "latest",
+    "next-themes": "latest",
+    "react": "latest",
+    "react-chartjs-2": "latest",
+    "react-dom": "latest",
+    "react-hook-form": "latest",
+    "sonner": "latest",
+    "swr": "latest",
+    "zod": "latest",
+    "zustand": "latest"
+  },
+  "devDependencies": {
+    "autoprefixer": "latest",
+    "eslint": "latest",
+    "eslint-config-next": "latest",
+    "msw": "latest",
+    "postcss": "latest",
+    "prettier": "latest",
+    "tailwindcss": "latest",
+    "typescript": "latest",
+    "@testing-library/jest-dom": "latest",
+    "@testing-library/react": "latest",
+    "@types/jest": "latest",
+    "jest": "latest"
+  }
+}

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,8 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  content: ['./app/**/*.{ts,tsx}', './components/**/*.{ts,tsx}'],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,25 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "strict": false,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["./*"]
+    },
+    "types": ["node", "jest"]
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- build sidebar/header layout with theme and toast providers
- add dashboard, users, forms, auth, settings, and system pages
- wire up data table, charts, and basic form validation
- configure Jest with Testing Library and add unit tests for fetcher utility and user schema
- add dialog, dropdown menu, tabs, toggle, and skeleton UI components

## Testing
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6897c09186bc832a9187a7f1221f81b2