### PR TITLE
Expand localization dictionaries for core UI

### DIFF
--- a/locales/en.ts
+++ b/locales/en.ts
@@ -14,9 +14,215 @@ const en = {
       logout: 'Logout',
     },
   },
+  header: {
+    title: 'Admin Dashboard',
+    actions: {
+      toggleSidebar: 'Toggle sidebar',
+      toggleTheme: 'Toggle theme',
+    },
+  },
+  common: {
+    loading: {
+      interface: 'Loading interface…',
+    },
+    errors: {
+      generic: 'Something went wrong',
+    },
+    empty: {
+      title: 'No results',
+      description: 'No records found',
+      dashboard: 'No dashboard data available',
+      revenueTrend: 'No revenue trend data available',
+      revenueByRegion: 'No regional revenue data available',
+      segments: 'No user distribution data available',
+      performance: 'No performance metrics available',
+      activity: 'No recent activity recorded',
+      users: 'No users found',
+    },
+    buttons: {
+      tryAgain: 'Try again',
+      viewAll: 'View All',
+      cancel: 'Cancel',
+      confirm: 'Confirm',
+      edit: 'Edit',
+      delete: 'Delete',
+      save: 'Save',
+    },
+    status: {
+      active: 'Active',
+      activeAccount: 'Active Account',
+      yes: 'Yes',
+      no: 'No',
+    },
+    table: {
+      summary: 'Showing {{from}} – {{to}} of {{total}} entries',
+      rowsPerPage: 'Rows per page',
+      page: 'Page {{current}} of {{total}}',
+      prev: 'Prev',
+      next: 'Next',
+      columns: 'Columns',
+      search: {
+        default: 'Search...',
+        single: 'Search {{field}}...',
+        multiple: 'Search {{fields}}...',
+      },
+    },
+    modals: {
+      deleteUserTitle: 'Delete user?',
+    },
+    messages: {
+      formSubmitted: 'Form submitted successfully!',
+      settingsSaved: 'Settings saved',
+      usersErrorTitle: 'Failed to load users',
+      usersErrorMessage: 'Please try again later.',
+      usersEmptyTitle: 'No users yet',
+      usersEmptyMessage: 'Invite your colleagues to get started.',
+    },
+    password: {
+      label: 'Password strength: {{level}}',
+      levels: {
+        weak: 'Weak',
+        fair: 'Fair',
+        good: 'Good',
+        strong: 'Strong',
+      },
+    },
+  },
   dashboard: {
+    page: {
+      title: 'Dashboard Overview',
+      description: "Welcome back! Here's a summary of your business metrics.",
+    },
+    errors: {
+      stats: 'Failed to load dashboard data',
+      users: 'Failed to load user data',
+    },
+    stats: {
+      totalUsers: 'Total Users',
+      vsLastMonth: 'vs last month',
+      activeUsers: 'Active Users',
+      ofTotalUsers: 'of total users',
+      revenue: 'Revenue',
+      avgSession: 'Avg. Session',
+      satisfaction: 'Satisfaction',
+      vsLastSurvey: 'vs last survey',
+    },
+    revenue: {
+      trendTitle: 'Revenue Trend',
+      regionTitle: 'Revenue by Region',
+      datasetLabel: 'Revenue',
+    },
     segments: {
+      title: 'Customer Segments',
       share: 'Share of active users',
+    },
+    performance: {
+      title: 'Performance Snapshot',
+      pageLoad: 'Page Load',
+      errorRate: 'Error Rate',
+      improvement: 'Improvement',
+      uptime: 'Uptime',
+      lastThirtyDays: 'Last 30 days',
+    },
+    recentUsers: {
+      title: 'Recent Users',
+    },
+    recentActivity: {
+      title: 'Recent Activity',
+    },
+  },
+  users: {
+    page: {
+      title: 'Users',
+      description: 'Manage your team members and their access levels.',
+    },
+    table: {
+      columns: {
+        name: 'Name',
+        email: 'Email',
+        role: 'Role',
+        active: 'Active',
+        actions: 'Actions',
+      },
+      active: {
+        yes: 'Yes',
+        no: 'No',
+      },
+    },
+  },
+  forms: {
+    page: {
+      title: 'Advanced User Registration',
+      description: 'Collect detailed account information and configure preferences at once.',
+    },
+    sections: {
+      basicInfo: 'Basic Information',
+      roleStatus: 'Role and Status',
+      skills: 'Skills',
+      address: 'Address',
+      notifications: 'Notification Preferences',
+      agreement: 'Agreement',
+    },
+    fields: {
+      fullName: 'Full Name',
+      fullNamePlaceholder: 'John Doe',
+      email: 'Email',
+      emailPlaceholder: 'john@example.com',
+      password: 'Password',
+      confirmPassword: 'Confirm Password',
+      phone: 'Phone',
+      phonePlaceholder: '+1234567890',
+      dateOfBirth: 'Date of Birth',
+      role: 'Role',
+      status: 'Status',
+      address: {
+        street: 'Street Address',
+        city: 'City',
+        state: 'State',
+        statePlaceholder: 'Select State',
+        zipCode: 'ZIP Code',
+        country: 'Country',
+      },
+      notifications: {
+        email: 'Email Notifications',
+        sms: 'SMS Notifications',
+        push: 'Push Notifications',
+      },
+      agreement: 'I agree to the Terms of Service and Privacy Policy',
+    },
+    roleOptions: {
+      admin: 'Admin',
+      editor: 'Editor',
+      viewer: 'Viewer',
+    },
+    actions: {
+      submit: 'Create Account',
+    },
+  },
+  settings: {
+    page: {
+      title: 'Settings',
+      description: 'Update your profile information and notification preferences.',
+    },
+    fields: {
+      namePlaceholder: 'Name',
+      emailPlaceholder: 'Email',
+    },
+  },
+  blank: {
+    page: {
+      title: 'Blank Page',
+      description: 'Start from a clean slate.',
+      content: 'Customize this page by adding components or data visualisations.',
+    },
+  },
+  system: {
+    error: {
+      title: 'Something went wrong',
+    },
+    notFound: {
+      title: '404 - Page Not Found',
+      description: 'The page you are looking for does not exist.',
     },
   },
 }

--- a/locales/es.ts
+++ b/locales/es.ts
@@ -14,9 +14,215 @@ const es = {
       logout: 'Cerrar sesión',
     },
   },
+  header: {
+    title: 'Panel de administración',
+    actions: {
+      toggleSidebar: 'Alternar barra lateral',
+      toggleTheme: 'Cambiar tema',
+    },
+  },
+  common: {
+    loading: {
+      interface: 'Cargando interfaz…',
+    },
+    errors: {
+      generic: 'Algo salió mal',
+    },
+    empty: {
+      title: 'Sin resultados',
+      description: 'No se encontraron registros',
+      dashboard: 'No hay datos del panel disponibles',
+      revenueTrend: 'No hay datos de tendencia de ingresos disponibles',
+      revenueByRegion: 'No hay datos de ingresos por región disponibles',
+      segments: 'No hay datos de distribución de usuarios disponibles',
+      performance: 'No hay métricas de rendimiento disponibles',
+      activity: 'No se registró actividad reciente',
+      users: 'No se encontraron usuarios',
+    },
+    buttons: {
+      tryAgain: 'Intentar de nuevo',
+      viewAll: 'Ver todo',
+      cancel: 'Cancelar',
+      confirm: 'Confirmar',
+      edit: 'Editar',
+      delete: 'Eliminar',
+      save: 'Guardar',
+    },
+    status: {
+      active: 'Activo',
+      activeAccount: 'Cuenta activa',
+      yes: 'Sí',
+      no: 'No',
+    },
+    table: {
+      summary: 'Mostrando {{from}}–{{to}} de {{total}} registros',
+      rowsPerPage: 'Filas por página',
+      page: 'Página {{current}} de {{total}}',
+      prev: 'Anterior',
+      next: 'Siguiente',
+      columns: 'Columnas',
+      search: {
+        default: 'Buscar...',
+        single: 'Buscar {{field}}...',
+        multiple: 'Buscar {{fields}}...',
+      },
+    },
+    modals: {
+      deleteUserTitle: '¿Eliminar usuario?',
+    },
+    messages: {
+      formSubmitted: '¡Formulario enviado con éxito!',
+      settingsSaved: 'Configuración guardada',
+      usersErrorTitle: 'No se pudieron cargar los usuarios',
+      usersErrorMessage: 'Vuelve a intentarlo más tarde.',
+      usersEmptyTitle: 'Aún no hay usuarios',
+      usersEmptyMessage: 'Invita a tus colegas para comenzar.',
+    },
+    password: {
+      label: 'Fortaleza de la contraseña: {{level}}',
+      levels: {
+        weak: 'Débil',
+        fair: 'Regular',
+        good: 'Buena',
+        strong: 'Fuerte',
+      },
+    },
+  },
   dashboard: {
+    page: {
+      title: 'Resumen del panel',
+      description: '¡Bienvenido de nuevo! Aquí tienes un resumen de tus métricas de negocio.',
+    },
+    errors: {
+      stats: 'Error al cargar los datos del panel',
+      users: 'Error al cargar los datos de usuarios',
+    },
+    stats: {
+      totalUsers: 'Usuarios totales',
+      vsLastMonth: 'vs. el mes pasado',
+      activeUsers: 'Usuarios activos',
+      ofTotalUsers: 'del total de usuarios',
+      revenue: 'Ingresos',
+      avgSession: 'Sesión prom.',
+      satisfaction: 'Satisfacción',
+      vsLastSurvey: 'vs. la última encuesta',
+    },
+    revenue: {
+      trendTitle: 'Tendencia de ingresos',
+      regionTitle: 'Ingresos por región',
+      datasetLabel: 'Ingresos',
+    },
     segments: {
+      title: 'Segmentos de clientes',
       share: 'Participación de usuarios activos',
+    },
+    performance: {
+      title: 'Instantánea de rendimiento',
+      pageLoad: 'Carga de página',
+      errorRate: 'Tasa de errores',
+      improvement: 'Mejora',
+      uptime: 'Disponibilidad',
+      lastThirtyDays: 'Últimos 30 días',
+    },
+    recentUsers: {
+      title: 'Usuarios recientes',
+    },
+    recentActivity: {
+      title: 'Actividad reciente',
+    },
+  },
+  users: {
+    page: {
+      title: 'Usuarios',
+      description: 'Administra a los miembros del equipo y sus niveles de acceso.',
+    },
+    table: {
+      columns: {
+        name: 'Nombre',
+        email: 'Correo electrónico',
+        role: 'Rol',
+        active: 'Activo',
+        actions: 'Acciones',
+      },
+      active: {
+        yes: 'Sí',
+        no: 'No',
+      },
+    },
+  },
+  forms: {
+    page: {
+      title: 'Registro avanzado de usuarios',
+      description: 'Recopila información detallada de la cuenta y configura preferencias a la vez.',
+    },
+    sections: {
+      basicInfo: 'Información básica',
+      roleStatus: 'Rol y estado',
+      skills: 'Habilidades',
+      address: 'Dirección',
+      notifications: 'Preferencias de notificación',
+      agreement: 'Acuerdo',
+    },
+    fields: {
+      fullName: 'Nombre completo',
+      fullNamePlaceholder: 'Juan Pérez',
+      email: 'Correo electrónico',
+      emailPlaceholder: 'juan@example.com',
+      password: 'Contraseña',
+      confirmPassword: 'Confirmar contraseña',
+      phone: 'Teléfono',
+      phonePlaceholder: '+34123456789',
+      dateOfBirth: 'Fecha de nacimiento',
+      role: 'Rol',
+      status: 'Estado',
+      address: {
+        street: 'Dirección',
+        city: 'Ciudad',
+        state: 'Estado',
+        statePlaceholder: 'Selecciona un estado',
+        zipCode: 'Código postal',
+        country: 'País',
+      },
+      notifications: {
+        email: 'Notificaciones por correo',
+        sms: 'Notificaciones por SMS',
+        push: 'Notificaciones push',
+      },
+      agreement: 'Acepto los Términos del servicio y la Política de privacidad',
+    },
+    roleOptions: {
+      admin: 'Administrador',
+      editor: 'Editor',
+      viewer: 'Visualizador',
+    },
+    actions: {
+      submit: 'Crear cuenta',
+    },
+  },
+  settings: {
+    page: {
+      title: 'Configuración',
+      description: 'Actualiza la información de tu perfil y las preferencias de notificación.',
+    },
+    fields: {
+      namePlaceholder: 'Nombre',
+      emailPlaceholder: 'Correo electrónico',
+    },
+  },
+  blank: {
+    page: {
+      title: 'Página en blanco',
+      description: 'Comienza desde cero.',
+      content: 'Personaliza esta página añadiendo componentes o visualizaciones de datos.',
+    },
+  },
+  system: {
+    error: {
+      title: 'Algo salió mal',
+    },
+    notFound: {
+      title: '404 - Página no encontrada',
+      description: 'La página que buscas no existe.',
     },
   },
 }

--- a/locales/fr.ts
+++ b/locales/fr.ts
@@ -10,13 +10,219 @@ const fr = {
       users: 'Utilisateurs',
       forms: 'Formulaires',
       settings: 'Paramètres',
-      blank: 'Page vierge',
+      blank: 'Page vide',
       logout: 'Se déconnecter',
     },
   },
+  header: {
+    title: 'Tableau de bord administrateur',
+    actions: {
+      toggleSidebar: 'Basculer la barre latérale',
+      toggleTheme: 'Changer de thème',
+    },
+  },
+  common: {
+    loading: {
+      interface: "Chargement de l'interface…",
+    },
+    errors: {
+      generic: 'Une erreur est survenue',
+    },
+    empty: {
+      title: 'Aucun résultat',
+      description: 'Aucun enregistrement trouvé',
+      dashboard: 'Aucune donnée du tableau de bord disponible',
+      revenueTrend: 'Aucune donnée de tendance des revenus disponible',
+      revenueByRegion: 'Aucune donnée de revenus par région disponible',
+      segments: 'Aucune donnée de répartition des utilisateurs disponible',
+      performance: 'Aucune mesure de performance disponible',
+      activity: 'Aucune activité récente enregistrée',
+      users: 'Aucun utilisateur trouvé',
+    },
+    buttons: {
+      tryAgain: 'Réessayer',
+      viewAll: 'Voir tout',
+      cancel: 'Annuler',
+      confirm: 'Confirmer',
+      edit: 'Modifier',
+      delete: 'Supprimer',
+      save: 'Enregistrer',
+    },
+    status: {
+      active: 'Actif',
+      activeAccount: 'Compte actif',
+      yes: 'Oui',
+      no: 'Non',
+    },
+    table: {
+      summary: 'Affichage de {{from}}–{{to}} sur {{total}} entrées',
+      rowsPerPage: 'Lignes par page',
+      page: 'Page {{current}} sur {{total}}',
+      prev: 'Précédent',
+      next: 'Suivant',
+      columns: 'Colonnes',
+      search: {
+        default: 'Rechercher...',
+        single: 'Rechercher {{field}}...',
+        multiple: 'Rechercher {{fields}}...',
+      },
+    },
+    modals: {
+      deleteUserTitle: 'Supprimer l’utilisateur ?',
+    },
+    messages: {
+      formSubmitted: 'Formulaire envoyé avec succès !',
+      settingsSaved: 'Paramètres enregistrés',
+      usersErrorTitle: 'Impossible de charger les utilisateurs',
+      usersErrorMessage: 'Veuillez réessayer plus tard.',
+      usersEmptyTitle: 'Pas encore d’utilisateurs',
+      usersEmptyMessage: 'Invitez vos collègues pour commencer.',
+    },
+    password: {
+      label: 'Solidité du mot de passe : {{level}}',
+      levels: {
+        weak: 'Faible',
+        fair: 'Moyen',
+        good: 'Bon',
+        strong: 'Excellent',
+      },
+    },
+  },
   dashboard: {
+    page: {
+      title: 'Vue d’ensemble du tableau de bord',
+      description: 'Content de vous revoir ! Voici un résumé de vos indicateurs métier.',
+    },
+    errors: {
+      stats: 'Échec du chargement des données du tableau de bord',
+      users: 'Échec du chargement des données utilisateurs',
+    },
+    stats: {
+      totalUsers: 'Utilisateurs au total',
+      vsLastMonth: 'par rapport au mois dernier',
+      activeUsers: 'Utilisateurs actifs',
+      ofTotalUsers: 'du total des utilisateurs',
+      revenue: 'Revenus',
+      avgSession: 'Session moy.',
+      satisfaction: 'Satisfaction',
+      vsLastSurvey: 'par rapport à la dernière enquête',
+    },
+    revenue: {
+      trendTitle: 'Tendance des revenus',
+      regionTitle: 'Revenus par région',
+      datasetLabel: 'Revenus',
+    },
     segments: {
+      title: 'Segments clients',
       share: 'Part des utilisateurs actifs',
+    },
+    performance: {
+      title: 'Instantané des performances',
+      pageLoad: 'Chargement de page',
+      errorRate: "Taux d'erreur",
+      improvement: 'Amélioration',
+      uptime: 'Disponibilité',
+      lastThirtyDays: '30 derniers jours',
+    },
+    recentUsers: {
+      title: 'Utilisateurs récents',
+    },
+    recentActivity: {
+      title: 'Activité récente',
+    },
+  },
+  users: {
+    page: {
+      title: 'Utilisateurs',
+      description: 'Gérez les membres de votre équipe et leurs niveaux d’accès.',
+    },
+    table: {
+      columns: {
+        name: 'Nom',
+        email: 'E-mail',
+        role: 'Rôle',
+        active: 'Actif',
+        actions: 'Actions',
+      },
+      active: {
+        yes: 'Oui',
+        no: 'Non',
+      },
+    },
+  },
+  forms: {
+    page: {
+      title: "Inscription avancée d'utilisateurs",
+      description: 'Collectez des informations détaillées sur le compte et configurez les préférences en une seule fois.',
+    },
+    sections: {
+      basicInfo: 'Informations de base',
+      roleStatus: 'Rôle et statut',
+      skills: 'Compétences',
+      address: 'Adresse',
+      notifications: 'Préférences de notification',
+      agreement: 'Accord',
+    },
+    fields: {
+      fullName: 'Nom complet',
+      fullNamePlaceholder: 'Jean Dupont',
+      email: 'E-mail',
+      emailPlaceholder: 'jean@example.com',
+      password: 'Mot de passe',
+      confirmPassword: 'Confirmer le mot de passe',
+      phone: 'Téléphone',
+      phonePlaceholder: '+33123456789',
+      dateOfBirth: 'Date de naissance',
+      role: 'Rôle',
+      status: 'Statut',
+      address: {
+        street: 'Adresse',
+        city: 'Ville',
+        state: 'État',
+        statePlaceholder: 'Sélectionnez un État',
+        zipCode: 'Code postal',
+        country: 'Pays',
+      },
+      notifications: {
+        email: 'Notifications par e-mail',
+        sms: 'Notifications par SMS',
+        push: 'Notifications push',
+      },
+      agreement: "J'accepte les Conditions d'utilisation et la Politique de confidentialité",
+    },
+    roleOptions: {
+      admin: 'Administrateur',
+      editor: 'Éditeur',
+      viewer: 'Lecteur',
+    },
+    actions: {
+      submit: 'Créer un compte',
+    },
+  },
+  settings: {
+    page: {
+      title: 'Paramètres',
+      description: 'Mettez à jour les informations de votre profil et vos préférences de notification.',
+    },
+    fields: {
+      namePlaceholder: 'Nom',
+      emailPlaceholder: 'E-mail',
+    },
+  },
+  blank: {
+    page: {
+      title: 'Page vide',
+      description: 'Repartez de zéro.',
+      content: 'Personnalisez cette page en ajoutant des composants ou des visualisations de données.',
+    },
+  },
+  system: {
+    error: {
+      title: 'Une erreur est survenue',
+    },
+    notFound: {
+      title: '404 - Page introuvable',
+      description: "La page que vous recherchez n'existe pas.",
     },
   },
 }

--- a/locales/ru.ts
+++ b/locales/ru.ts
@@ -10,13 +10,219 @@ const ru = {
       users: 'Пользователи',
       forms: 'Формы',
       settings: 'Настройки',
-      blank: 'Чистая страница',
+      blank: 'Пустая страница',
       logout: 'Выйти',
     },
   },
+  header: {
+    title: 'Админ-панель',
+    actions: {
+      toggleSidebar: 'Переключить боковую панель',
+      toggleTheme: 'Переключить тему',
+    },
+  },
+  common: {
+    loading: {
+      interface: 'Загрузка интерфейса…',
+    },
+    errors: {
+      generic: 'Что-то пошло не так',
+    },
+    empty: {
+      title: 'Нет результатов',
+      description: 'Записи не найдены',
+      dashboard: 'Данные для панели недоступны',
+      revenueTrend: 'Нет данных о динамике дохода',
+      revenueByRegion: 'Нет данных о доходе по регионам',
+      segments: 'Нет данных о распределении пользователей',
+      performance: 'Нет данных о показателях эффективности',
+      activity: 'Последняя активность отсутствует',
+      users: 'Пользователи не найдены',
+    },
+    buttons: {
+      tryAgain: 'Повторить попытку',
+      viewAll: 'Показать все',
+      cancel: 'Отмена',
+      confirm: 'Подтвердить',
+      edit: 'Редактировать',
+      delete: 'Удалить',
+      save: 'Сохранить',
+    },
+    status: {
+      active: 'Активен',
+      activeAccount: 'Активный аккаунт',
+      yes: 'Да',
+      no: 'Нет',
+    },
+    table: {
+      summary: 'Показаны записи {{from}}–{{to}} из {{total}}',
+      rowsPerPage: 'Строк на странице',
+      page: 'Страница {{current}} из {{total}}',
+      prev: 'Назад',
+      next: 'Вперёд',
+      columns: 'Столбцы',
+      search: {
+        default: 'Поиск...',
+        single: 'Поиск по {{field}}...',
+        multiple: 'Поиск по {{fields}}...',
+      },
+    },
+    modals: {
+      deleteUserTitle: 'Удалить пользователя?',
+    },
+    messages: {
+      formSubmitted: 'Форма успешно отправлена!',
+      settingsSaved: 'Настройки сохранены',
+      usersErrorTitle: 'Не удалось загрузить пользователей',
+      usersErrorMessage: 'Попробуйте ещё раз позже.',
+      usersEmptyTitle: 'Пока нет пользователей',
+      usersEmptyMessage: 'Пригласите коллег, чтобы начать работу.',
+    },
+    password: {
+      label: 'Надёжность пароля: {{level}}',
+      levels: {
+        weak: 'Слабый',
+        fair: 'Средний',
+        good: 'Хороший',
+        strong: 'Отличный',
+      },
+    },
+  },
   dashboard: {
+    page: {
+      title: 'Обзор панели',
+      description: 'С возвращением! Краткое резюме показателей вашего бизнеса.',
+    },
+    errors: {
+      stats: 'Не удалось загрузить данные панели',
+      users: 'Не удалось загрузить данные пользователей',
+    },
+    stats: {
+      totalUsers: 'Всего пользователей',
+      vsLastMonth: 'к прошлому месяцу',
+      activeUsers: 'Активные пользователи',
+      ofTotalUsers: 'от общего числа',
+      revenue: 'Доход',
+      avgSession: 'Средняя сессия',
+      satisfaction: 'Удовлетворённость',
+      vsLastSurvey: 'к прошлому опросу',
+    },
+    revenue: {
+      trendTitle: 'Динамика дохода',
+      regionTitle: 'Доход по регионам',
+      datasetLabel: 'Доход',
+    },
     segments: {
+      title: 'Сегменты клиентов',
       share: 'Доля активных пользователей',
+    },
+    performance: {
+      title: 'Сводка по эффективности',
+      pageLoad: 'Загрузка страницы',
+      errorRate: 'Доля ошибок',
+      improvement: 'Улучшение',
+      uptime: 'Аптайм',
+      lastThirtyDays: 'Последние 30 дней',
+    },
+    recentUsers: {
+      title: 'Недавние пользователи',
+    },
+    recentActivity: {
+      title: 'Недавняя активность',
+    },
+  },
+  users: {
+    page: {
+      title: 'Пользователи',
+      description: 'Управляйте участниками команды и их уровнями доступа.',
+    },
+    table: {
+      columns: {
+        name: 'Имя',
+        email: 'Email',
+        role: 'Роль',
+        active: 'Активен',
+        actions: 'Действия',
+      },
+      active: {
+        yes: 'Да',
+        no: 'Нет',
+      },
+    },
+  },
+  forms: {
+    page: {
+      title: 'Расширенная регистрация пользователя',
+      description: 'Соберите расширенные данные аккаунта и настройте предпочтения за один раз.',
+    },
+    sections: {
+      basicInfo: 'Основная информация',
+      roleStatus: 'Роль и статус',
+      skills: 'Навыки',
+      address: 'Адрес',
+      notifications: 'Настройки уведомлений',
+      agreement: 'Согласие',
+    },
+    fields: {
+      fullName: 'Полное имя',
+      fullNamePlaceholder: 'Иван Иванов',
+      email: 'Email',
+      emailPlaceholder: 'ivan@example.com',
+      password: 'Пароль',
+      confirmPassword: 'Подтверждение пароля',
+      phone: 'Телефон',
+      phonePlaceholder: '+79991234567',
+      dateOfBirth: 'Дата рождения',
+      role: 'Роль',
+      status: 'Статус',
+      address: {
+        street: 'Улица и дом',
+        city: 'Город',
+        state: 'Штат',
+        statePlaceholder: 'Выберите штат',
+        zipCode: 'Почтовый индекс',
+        country: 'Страна',
+      },
+      notifications: {
+        email: 'Email-уведомления',
+        sms: 'SMS-уведомления',
+        push: 'Push-уведомления',
+      },
+      agreement: 'Я принимаю Условия использования и Политику конфиденциальности',
+    },
+    roleOptions: {
+      admin: 'Администратор',
+      editor: 'Редактор',
+      viewer: 'Наблюдатель',
+    },
+    actions: {
+      submit: 'Создать аккаунт',
+    },
+  },
+  settings: {
+    page: {
+      title: 'Настройки',
+      description: 'Обновите информацию профиля и параметры уведомлений.',
+    },
+    fields: {
+      namePlaceholder: 'Имя',
+      emailPlaceholder: 'Email',
+    },
+  },
+  blank: {
+    page: {
+      title: 'Пустая страница',
+      description: 'Начните с чистого листа.',
+      content: 'Настройте эту страницу, добавив компоненты или визуализацию данных.',
+    },
+  },
+  system: {
+    error: {
+      title: 'Что-то пошло не так',
+    },
+    notFound: {
+      title: '404 — Страница не найдена',
+      description: 'Страница, которую вы ищете, не существует.',
     },
   },
 }


### PR DESCRIPTION
## Summary
- extend the English locale dictionary with shared UI labels, page metadata, and component-specific strings needed for app-wide translations
- provide equivalent Russian, Spanish, and French translations so all supported locales stay in sync

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d3d3805aa4832ab611581d754dfcfb