### PR TITLE
Localize remaining dashboard UI strings

### DIFF
--- a/app/blank/page.tsx
+++ b/app/blank/page.tsx
@@ -1,10 +1,17 @@
+"use client"
+
 import PageLayout from '@/components/layout/PageLayout'
+import { useLocale } from '@/contexts/LocaleProvider'
 
 export default function BlankPage() {
+  const { t } = useLocale()
   return (
-    <PageLayout title="Blank Page" description="Start from a clean slate.">
+    <PageLayout
+      title={t('blank.page.title', 'Blank Page')}
+      description={t('blank.page.description', 'Start from a clean slate.')}
+    >
       <div className="section-container text-sm text-muted-foreground">
-        Customize this page by adding components or data visualisations.
+        {t('blank.page.content', 'Customize this page by adding components or data visualisations.')}
       </div>
     </PageLayout>
   )

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -11,8 +11,10 @@ import SegmentsList from '@/components/dashboard/SegmentsList'
 import PerformanceSnapshot from '@/components/dashboard/PerformanceSnapshot'
 import RecentUsersTable from '@/components/dashboard/RecentUsersTable'
 import RecentActivitySection from '@/components/dashboard/RecentActivitySection'
+import { useLocale } from '@/contexts/LocaleProvider'
 
 export default function DashboardPage() {
+  const { t } = useLocale()
   const {
     data: stats,
     isLoading: isLoadingStats,
@@ -34,7 +36,7 @@ export default function DashboardPage() {
   if (isStatsError) {
     return (
       <ErrorState
-        message="Failed to load dashboard data"
+        message={t('dashboard.errors.stats', 'Failed to load dashboard data')}
         retry={() => mutateStats()}
       />
     )
@@ -43,20 +45,20 @@ export default function DashboardPage() {
   if (isUsersError) {
     return (
       <ErrorState
-        message="Failed to load user data"
+        message={t('dashboard.errors.users', 'Failed to load user data')}
         retry={() => mutateUsers()}
       />
     )
   }
 
   if (!stats) {
-    return <EmptyState message="No dashboard data available" />
+    return <EmptyState message={t('common.empty.dashboard', 'No dashboard data available')} />
   }
 
   return (
     <PageLayout
-      title="Dashboard Overview"
-      description="Welcome back! Here's a summary of your business metrics."
+      title={t('dashboard.page.title', 'Dashboard Overview')}
+      description={t('dashboard.page.description', "Welcome back! Here's a summary of your business metrics.")}
     >
       <StatsGrid stats={stats} />
 

--- a/app/forms/page.tsx
+++ b/app/forms/page.tsx
@@ -13,6 +13,7 @@ import SkillsSelector from '@/components/forms/SkillsSelector'
 import AddressSection from '@/components/forms/AddressSection'
 import NotificationsSection from '@/components/forms/NotificationsSection'
 import AgreementSection from '@/components/forms/AgreementSection'
+import { useLocale } from '@/contexts/LocaleProvider'
 
 export default function FormsPage() {
   const {
@@ -39,16 +40,20 @@ export default function FormsPage() {
 
   const { strength: passwordStrength, handlePasswordChange } = usePasswordStrength()
   const { isSkillSelected } = useSkillsFieldArray(control)
+  const { t } = useLocale()
 
   const onSubmit = (data: UserFormValues) => {
     console.log(data)
-    toast.success('Form submitted successfully!')
+    toast.success(t('common.messages.formSubmitted', 'Form submitted successfully!'))
   }
 
   return (
     <PageLayout
-      title="Advanced User Registration"
-      description="Collect detailed account information and configure preferences at once."
+      title={t('forms.page.title', 'Advanced User Registration')}
+      description={t(
+        'forms.page.description',
+        'Collect detailed account information and configure preferences at once.'
+      )}
       contentClassName="space-y-6"
     >
       <div className="mx-auto max-w-2xl">

--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -6,6 +6,7 @@ import { Button } from '@/components/ui/Button'
 import { Input } from '@/components/ui/Input'
 import { toast } from 'sonner'
 import PageLayout from '@/components/layout/PageLayout'
+import { useLocale } from '@/contexts/LocaleProvider'
 
 const schema = z.object({
   name: z.string().min(1),
@@ -18,28 +19,29 @@ export default function SettingsPage() {
     handleSubmit,
     formState: { errors },
   } = useForm<{ name: string; email: string }>({ resolver: zodResolver(schema) })
+  const { t } = useLocale()
 
   const onSubmit = () => {
-    toast.success('Settings saved')
+    toast.success(t('common.messages.settingsSaved', 'Settings saved'))
   }
 
   return (
     <PageLayout
-      title="Settings"
-      description="Update your profile information and notification preferences."
+      title={t('settings.page.title', 'Settings')}
+      description={t('settings.page.description', 'Update your profile information and notification preferences.')}
       contentClassName="space-y-6"
     >
       <div className="section-container max-w-md">
         <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
           <div>
-            <Input placeholder="Name" {...register('name')} />
+            <Input placeholder={t('settings.fields.namePlaceholder', 'Name')} {...register('name')} />
             {errors.name && <p className="text-sm text-red-600">{errors.name.message}</p>}
           </div>
           <div>
-            <Input type="email" placeholder="Email" {...register('email')} />
+            <Input type="email" placeholder={t('settings.fields.emailPlaceholder', 'Email')} {...register('email')} />
             {errors.email && <p className="text-sm text-red-600">{errors.email.message}</p>}
           </div>
-          <Button type="submit">Save</Button>
+          <Button type="submit">{t('common.buttons.save', 'Save')}</Button>
         </form>
       </div>
     </PageLayout>

--- a/app/users/page.tsx
+++ b/app/users/page.tsx
@@ -10,29 +10,39 @@ import ConfirmModal from '@/components/common/ConfirmModal'
 import EmptyState from '@/components/common/EmptyState'
 import PageLayout from '@/components/layout/PageLayout'
 import { TableSkeleton } from '@/components/loading/Skeletons'
+import { useLocale } from '@/contexts/LocaleProvider'
 
 export default function UsersPage() {
   const { data, mutate, isLoading, error } = useSWR<User[]>('/api/users', fetcher)
   const [deleteId, setDeleteId] = useState<string | null>(null)
+  const { t } = useLocale()
 
   const columns: ColumnDef<User>[] = [
-    { header: 'Name', accessorKey: 'name' },
-    { header: 'Email', accessorKey: 'email' },
-    { header: 'Role', accessorKey: 'role' },
-    { header: 'Active', accessorKey: 'active', cell: ({ row }) => (row.original.active ? 'Yes' : 'No') },
+    { header: t('users.table.columns.name', 'Name'), accessorKey: 'name' },
+    { header: t('users.table.columns.email', 'Email'), accessorKey: 'email' },
+    { header: t('users.table.columns.role', 'Role'), accessorKey: 'role' },
     {
-      header: 'Actions',
+      header: t('users.table.columns.active', 'Active'),
+      accessorKey: 'active',
+      cell: ({ row }) => (row.original.active ? t('users.table.active.yes', 'Yes') : t('users.table.active.no', 'No')),
+    },
+    {
+      header: t('users.table.columns.actions', 'Actions'),
       cell: ({ row }) => (
         <div className="flex gap-2">
-          <Button type="button" onClick={() => alert('Edit ' + row.original.id)} className="px-2 py-1">
-            Edit
+          <Button
+            type="button"
+            onClick={() => alert(`${t('common.buttons.edit', 'Edit')} ${row.original.id}`)}
+            className="px-2 py-1"
+          >
+            {t('common.buttons.edit', 'Edit')}
           </Button>
           <Button
             type="button"
             onClick={() => setDeleteId(row.original.id)}
             className="bg-red-600 px-2 py-1"
           >
-            Delete
+            {t('common.buttons.delete', 'Delete')}
           </Button>
         </div>
       ),
@@ -49,8 +59,8 @@ export default function UsersPage() {
   if (isLoading) {
     return (
       <PageLayout
-        title="Users"
-        description="Manage your team members and their access levels."
+        title={t('users.page.title', 'Users')}
+        description={t('users.page.description', 'Manage your team members and their access levels.')}
       >
         <div className="section-container">
           <TableSkeleton columns={columns.length} rows={6} />
@@ -62,11 +72,14 @@ export default function UsersPage() {
   if (error) {
     return (
       <PageLayout
-        title="Users"
-        description="Manage your team members and their access levels."
+        title={t('users.page.title', 'Users')}
+        description={t('users.page.description', 'Manage your team members and their access levels.')}
       >
         <div className="section-container">
-          <EmptyState title="Failed to load users" message="Please try again later." />
+          <EmptyState
+            title={t('common.messages.usersErrorTitle', 'Failed to load users')}
+            message={t('common.messages.usersErrorMessage', 'Please try again later.')}
+          />
         </div>
       </PageLayout>
     )
@@ -78,8 +91,8 @@ export default function UsersPage() {
   return (
     <>
       <PageLayout
-        title="Users"
-        description="Manage your team members and their access levels."
+        title={t('users.page.title', 'Users')}
+        description={t('users.page.description', 'Manage your team members and their access levels.')}
       >
         <div className="section-container">
           {hasUsers ? (
@@ -90,13 +103,16 @@ export default function UsersPage() {
               initialPageSize={10}
             />
           ) : (
-            <EmptyState title="No users yet" message="Invite your colleagues to get started." />
+            <EmptyState
+              title={t('common.messages.usersEmptyTitle', 'No users yet')}
+              message={t('common.messages.usersEmptyMessage', 'Invite your colleagues to get started.')}
+            />
           )}
         </div>
       </PageLayout>
       <ConfirmModal
         open={!!deleteId}
-        title="Delete user?"
+        title={t('common.modals.deleteUserTitle', 'Delete user?')}
         onConfirm={handleDelete}
         onCancel={() => setDeleteId(null)}
       />

--- a/components/charts/LineChart.tsx
+++ b/components/charts/LineChart.tsx
@@ -15,7 +15,7 @@ import type { SeriesPoint } from '@/lib/types'
 
 ChartJS.register(CategoryScale, LinearScale, PointElement, LineElement, Tooltip, Legend)
 
-export default function LineChart({ data }: { data: SeriesPoint[] }) {
+export default function LineChart({ data, label = 'Value' }: { data: SeriesPoint[]; label?: string }) {
   const { locale } = useLocale()
 
   const labels = useMemo(() => {
@@ -46,7 +46,7 @@ export default function LineChart({ data }: { data: SeriesPoint[] }) {
     labels,
     datasets: [
       {
-        label: 'Value',
+        label,
         data: data.map((d) => d.value),
         borderColor: 'rgb(37, 99, 235)',
         backgroundColor: 'rgba(37, 99, 235, 0.5)',

--- a/components/common/AvatarMenu.tsx
+++ b/components/common/AvatarMenu.tsx
@@ -11,7 +11,7 @@ export default function AvatarMenu() {
       <button
         className="h-8 w-8 rounded-full bg-gray-300"
         onClick={() => setOpen((o) => !o)}
-        aria-label="Toggle menu"
+        aria-label={t('header.actions.toggleAccountMenu', 'Toggle menu')}
       />
       {open && (
         <div className="absolute right-0 mt-2 w-40 rounded border bg-white shadow dark:bg-gray-800">

--- a/components/common/ConfirmModal.tsx
+++ b/components/common/ConfirmModal.tsx
@@ -1,5 +1,7 @@
 'use client'
 
+import { useLocale } from '@/contexts/LocaleProvider'
+
 type Props = {
   open: boolean
   title: string
@@ -9,6 +11,7 @@ type Props = {
 }
 
 export default function ConfirmModal({ open, title, description, onConfirm, onCancel }: Props) {
+  const { t } = useLocale()
   if (!open) return null
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
@@ -17,10 +20,10 @@ export default function ConfirmModal({ open, title, description, onConfirm, onCa
         {description && <p className="mb-4 text-sm text-gray-600 dark:text-gray-300">{description}</p>}
         <div className="flex justify-end gap-2">
           <button className="rounded border px-3 py-1" onClick={onCancel}>
-            Cancel
+            {t('common.buttons.cancel', 'Cancel')}
           </button>
           <button className="rounded bg-red-600 px-3 py-1 text-white" onClick={onConfirm}>
-            Confirm
+            {t('common.buttons.confirm', 'Confirm')}
           </button>
         </div>
       </div>

--- a/components/common/EmptyState.tsx
+++ b/components/common/EmptyState.tsx
@@ -1,8 +1,14 @@
-export default function EmptyState({ title = 'No results', message = 'No records found' }: { title?: string; message?: string }) {
+'use client'
+import { useLocale } from '@/contexts/LocaleProvider'
+
+export default function EmptyState({ title, message }: { title?: string; message?: string }) {
+  const { t } = useLocale()
+  const resolvedTitle = title ?? t('common.empty.title', 'No results')
+  const resolvedMessage = message ?? t('common.empty.description', 'No records found')
   return (
     <div className="py-10 text-center text-sm text-gray-500">
-      <p className="font-medium">{title}</p>
-      <p>{message}</p>
+      <p className="font-medium">{resolvedTitle}</p>
+      <p>{resolvedMessage}</p>
     </div>
   )
 }

--- a/components/common/ErrorState.tsx
+++ b/components/common/ErrorState.tsx
@@ -1,24 +1,27 @@
 'use client'
 import { XCircleIcon } from '@heroicons/react/20/solid'
+import { useLocale } from '@/contexts/LocaleProvider'
 
 type Props = {
   message?: string
   retry?: () => void
 }
 
-export default function ErrorState({ message = 'Something went wrong', retry }: Props) {
+export default function ErrorState({ message, retry }: Props) {
+  const { t } = useLocale()
+  const resolvedMessage = message ?? t('common.errors.generic', 'Something went wrong')
   return (
     <div className="rounded-lg border border-red-100 bg-red-50 p-4 dark:border-red-900 dark:bg-red-950">
       <div className="flex items-start">
         <XCircleIcon className="h-5 w-5 text-red-600 dark:text-red-500" />
         <div className="ml-3">
-          <p className="text-sm text-red-600 dark:text-red-500">{message}</p>
+          <p className="text-sm text-red-600 dark:text-red-500">{resolvedMessage}</p>
           {retry && (
             <button
               onClick={retry}
               className="mt-2 text-sm font-medium text-red-600 hover:text-red-500 dark:text-red-500 dark:hover:text-red-400"
             >
-              Try again
+              {t('common.buttons.tryAgain', 'Try again')}
             </button>
           )}
         </div>

--- a/components/dashboard/PerformanceMetrics.tsx
+++ b/components/dashboard/PerformanceMetrics.tsx
@@ -1,5 +1,6 @@
 'use client'
 import { PerformanceMetrics as PerformanceMetricsType } from '@/lib/types'
+import { useLocale } from '@/contexts/LocaleProvider'
 
 type Props = {
   metrics: PerformanceMetricsType
@@ -7,13 +8,14 @@ type Props = {
 }
 
 export default function PerformanceMetrics({ metrics, className = '' }: Props) {
+  const { t } = useLocale()
   return (
     <div className={`rounded bg-white p-4 shadow dark:bg-gray-800 ${className}`}>
-      <h3 className="mb-4 text-lg font-semibold">System Performance</h3>
+      <h3 className="mb-4 text-lg font-semibold">{t('dashboard.performance.title', 'Performance Snapshot')}</h3>
       <div className="space-y-4">
         <div>
           <div className="mb-1 flex items-center justify-between">
-            <span className="text-sm text-gray-500">Page Load Time</span>
+            <span className="text-sm text-gray-500">{t('dashboard.performance.pageLoad', 'Page Load')}</span>
             <span className="text-sm font-medium">{metrics.pageLoadTime}s</span>
           </div>
           <div className="h-2 rounded bg-gray-200">
@@ -26,7 +28,7 @@ export default function PerformanceMetrics({ metrics, className = '' }: Props) {
 
         <div>
           <div className="mb-1 flex items-center justify-between">
-            <span className="text-sm text-gray-500">Error Rate</span>
+            <span className="text-sm text-gray-500">{t('dashboard.performance.errorRate', 'Error Rate')}</span>
             <span className="text-sm font-medium">{metrics.errorRate}%</span>
           </div>
           <div className="h-2 rounded bg-gray-200">
@@ -39,7 +41,7 @@ export default function PerformanceMetrics({ metrics, className = '' }: Props) {
 
         <div>
           <div className="mb-1 flex items-center justify-between">
-            <span className="text-sm text-gray-500">Uptime</span>
+            <span className="text-sm text-gray-500">{t('dashboard.performance.uptime', 'Uptime')}</span>
             <span className="text-sm font-medium">{metrics.uptime}%</span>
           </div>
           <div className="h-2 rounded bg-gray-200">

--- a/components/dashboard/PerformanceSnapshot.tsx
+++ b/components/dashboard/PerformanceSnapshot.tsx
@@ -2,42 +2,44 @@
 import EmptyState from '@/components/common/EmptyState'
 import StatCard from '@/components/dashboard/StatCard'
 import { DashboardStats } from '@/lib/types'
+import { useLocale } from '@/contexts/LocaleProvider'
 
 type PerformanceSnapshotProps = {
   metrics: DashboardStats['performanceMetrics']
 }
 
 export default function PerformanceSnapshot({ metrics }: PerformanceSnapshotProps) {
+  const { t } = useLocale()
   if (!metrics) {
     return (
       <div className="section-container">
-        <h3 className="heading-4 mb-6">Performance Snapshot</h3>
-        <EmptyState message="No performance metrics available" />
+        <h3 className="heading-4 mb-6">{t('dashboard.performance.title', 'Performance Snapshot')}</h3>
+        <EmptyState message={t('common.empty.performance', 'No performance metrics available')} />
       </div>
     )
   }
 
   return (
     <div className="section-container">
-      <h3 className="heading-4 mb-6">Performance Snapshot</h3>
+      <h3 className="heading-4 mb-6">{t('dashboard.performance.title', 'Performance Snapshot')}</h3>
       <div className="grid gap-4 sm:grid-cols-3">
         <StatCard
-          label="Page Load"
+          label={t('dashboard.performance.pageLoad', 'Page Load')}
           value={`${metrics.pageLoadTime}s`}
           trend={-8}
-          trendLabel="vs last month"
+          trendLabel={t('dashboard.stats.vsLastMonth', 'vs last month')}
         />
         <StatCard
-          label="Error Rate"
+          label={t('dashboard.performance.errorRate', 'Error Rate')}
           value={`${metrics.errorRate}%`}
           trend={-metrics.errorRate}
-          trendLabel="Improvement"
+          trendLabel={t('dashboard.performance.improvement', 'Improvement')}
         />
         <StatCard
-          label="Uptime"
+          label={t('dashboard.performance.uptime', 'Uptime')}
           value={`${metrics.uptime}%`}
           trend={0.05}
-          trendLabel="Last 30 days"
+          trendLabel={t('dashboard.performance.lastThirtyDays', 'Last 30 days')}
         />
       </div>
     </div>

--- a/components/dashboard/RecentActivitySection.tsx
+++ b/components/dashboard/RecentActivitySection.tsx
@@ -2,6 +2,7 @@
 import EmptyState from '@/components/common/EmptyState'
 import RecentActivityFeed from '@/components/dashboard/RecentActivityFeed'
 import { DashboardStats } from '@/lib/types'
+import { useLocale } from '@/contexts/LocaleProvider'
 
 type RecentActivitySectionProps = {
   activity?: DashboardStats['recentActivity']
@@ -9,14 +10,15 @@ type RecentActivitySectionProps = {
 
 export default function RecentActivitySection({ activity }: RecentActivitySectionProps) {
   const hasActivity = Boolean(activity && activity.length > 0)
+  const { t } = useLocale()
 
   return (
     <div className="section-container">
-      <h3 className="heading-4 mb-6">Recent Activity</h3>
+      <h3 className="heading-4 mb-6">{t('dashboard.recentActivity.title', 'Recent Activity')}</h3>
       {hasActivity ? (
         <RecentActivityFeed items={activity!} />
       ) : (
-        <EmptyState message="No recent activity recorded" />
+        <EmptyState message={t('common.empty.activity', 'No recent activity recorded')} />
       )}
     </div>
   )

--- a/components/dashboard/RecentUsersTable.tsx
+++ b/components/dashboard/RecentUsersTable.tsx
@@ -1,8 +1,10 @@
 "use client"
+import { useMemo } from 'react'
 import DataTable from '@/components/data-table/DataTable'
 import EmptyState from '@/components/common/EmptyState'
-import { RECENT_USERS_COLUMNS } from '@/components/dashboard/columns'
+import { getRecentUsersColumns } from '@/components/dashboard/columns'
 import { User } from '@/lib/types'
+import { useLocale } from '@/contexts/LocaleProvider'
 
 type RecentUsersTableProps = {
   users?: User[]
@@ -12,25 +14,27 @@ type RecentUsersTableProps = {
 export default function RecentUsersTable({ users, onViewAll }: RecentUsersTableProps) {
   const hasUsers = (users?.length ?? 0) > 0
   const tableData = hasUsers ? (users ?? []).slice(0, 5) : []
+  const { t } = useLocale()
+  const columns = useMemo(() => getRecentUsersColumns(t), [t])
 
   return (
     <div className="section-container">
       <div className="mb-6 flex items-center justify-between">
-        <h3 className="heading-4">Recent Users</h3>
+        <h3 className="heading-4">{t('dashboard.recentUsers.title', 'Recent Users')}</h3>
         <button type="button" className="btn-outline" onClick={onViewAll}>
-          View All
+          {t('common.buttons.viewAll', 'View All')}
         </button>
       </div>
       <div className="table-container">
         {hasUsers ? (
           <DataTable
-            columns={RECENT_USERS_COLUMNS}
+            columns={columns}
             data={tableData}
             searchKeys={['name', 'email']}
             initialPageSize={5}
           />
         ) : (
-          <EmptyState message="No users found" />
+          <EmptyState message={t('common.empty.users', 'No users found')} />
         )}
       </div>
     </div>

--- a/components/dashboard/RevenueSection.tsx
+++ b/components/dashboard/RevenueSection.tsx
@@ -12,7 +12,7 @@ type RevenueSectionProps = {
 }
 
 export default function RevenueSection({ trend, revenueByRegion }: RevenueSectionProps) {
-  const { locale } = useLocale()
+  const { locale, t } = useLocale()
   const hasTrendData = trend.length > 0
   const hasRegionData = revenueByRegion.length > 0
   const localizedRevenueByRegion = useMemo(
@@ -27,20 +27,20 @@ export default function RevenueSection({ trend, revenueByRegion }: RevenueSectio
   return (
     <>
       <div className="section-container">
-        <h3 className="heading-4 mb-6">Revenue Trend</h3>
+        <h3 className="heading-4 mb-6">{t('dashboard.revenue.trendTitle', 'Revenue Trend')}</h3>
         {hasTrendData ? (
-          <LineChart data={trend} />
+          <LineChart data={trend} label={t('dashboard.revenue.datasetLabel', 'Revenue')} />
         ) : (
-          <EmptyState message="No revenue trend data available" />
+          <EmptyState message={t('common.empty.revenueTrend', 'No revenue trend data available')} />
         )}
       </div>
 
       <div className="section-container">
-        <h3 className="heading-4 mb-6">Revenue by Region</h3>
+        <h3 className="heading-4 mb-6">{t('dashboard.revenue.regionTitle', 'Revenue by Region')}</h3>
         {hasRegionData ? (
-          <BarChart data={localizedRevenueByRegion} label="Revenue" />
+          <BarChart data={localizedRevenueByRegion} label={t('dashboard.revenue.datasetLabel', 'Revenue')} />
         ) : (
-          <EmptyState message="No regional revenue data available" />
+          <EmptyState message={t('common.empty.revenueByRegion', 'No regional revenue data available')} />
         )}
       </div>
     </>

--- a/components/dashboard/SegmentsList.tsx
+++ b/components/dashboard/SegmentsList.tsx
@@ -16,7 +16,7 @@ export default function SegmentsList({ segments }: SegmentsListProps) {
 
   return (
     <div className="section-container">
-      <h3 className="heading-4 mb-6">Customer Segments</h3>
+      <h3 className="heading-4 mb-6">{t('dashboard.segments.title', 'Customer Segments')}</h3>
       {hasSegments ? (
         <div className="space-y-3">
           {segments.map((segment) => (
@@ -37,7 +37,7 @@ export default function SegmentsList({ segments }: SegmentsListProps) {
           ))}
         </div>
       ) : (
-        <EmptyState message="No user distribution data available" />
+        <EmptyState message={t('common.empty.segments', 'No user distribution data available')} />
       )}
     </div>
   )

--- a/components/dashboard/StatsGrid.tsx
+++ b/components/dashboard/StatsGrid.tsx
@@ -1,4 +1,5 @@
 "use client"
+import { useLocale } from '@/contexts/LocaleProvider'
 import StatCard from '@/components/dashboard/StatCard'
 import { DashboardStats } from '@/lib/types'
 
@@ -7,6 +8,7 @@ type StatsGridProps = {
 }
 
 export default function StatsGrid({ stats }: StatsGridProps) {
+  const { locale, t } = useLocale()
   const activeUsersPercent = Math.round((stats.activeUsers / stats.users) * 100)
   const prevRevenue = stats.series[stats.series.length - 2]?.value || 0
   const currentRevenue = stats.series[stats.series.length - 1]?.value || 0
@@ -17,32 +19,32 @@ export default function StatsGrid({ stats }: StatsGridProps) {
   return (
     <div className="grid-container sm:grid-cols-2 lg:grid-cols-4">
       <StatCard
-        label="Total Users"
-        value={stats.users.toLocaleString()}
+        label={t('dashboard.stats.totalUsers', 'Total Users')}
+        value={stats.users.toLocaleString(locale)}
         trend={stats.growthPct}
-        trendLabel="vs last month"
+        trendLabel={t('dashboard.stats.vsLastMonth', 'vs last month')}
       />
       <StatCard
-        label="Active Users"
-        value={stats.activeUsers.toLocaleString()}
+        label={t('dashboard.stats.activeUsers', 'Active Users')}
+        value={stats.activeUsers.toLocaleString(locale)}
         trend={activeUsersPercent}
-        trendLabel="of total users"
+        trendLabel={t('dashboard.stats.ofTotalUsers', 'of total users')}
       />
       <StatCard
-        label="Revenue"
-        value={`$${stats.revenue.toLocaleString()}`}
+        label={t('dashboard.stats.revenue', 'Revenue')}
+        value={new Intl.NumberFormat(locale, { style: 'currency', currency: 'USD' }).format(stats.revenue)}
         trend={revenueTrend}
-        trendLabel="vs last month"
+        trendLabel={t('dashboard.stats.vsLastMonth', 'vs last month')}
       />
       <StatCard
-        label="Avg. Session"
-        value={`${stats.avgSessionDuration} min`}
+        label={t('dashboard.stats.avgSession', 'Avg. Session')}
+        value={`${stats.avgSessionDuration} ${t('common.units.minutesShort', 'min')}`}
       />
       <StatCard
-        label="Satisfaction"
+        label={t('dashboard.stats.satisfaction', 'Satisfaction')}
         value={`${stats.customerSatisfaction}%`}
         trend={stats.customerSatisfaction - 88}
-        trendLabel="vs last survey"
+        trendLabel={t('dashboard.stats.vsLastSurvey', 'vs last survey')}
       />
     </div>
   )

--- a/components/dashboard/columns.ts
+++ b/components/dashboard/columns.ts
@@ -1,8 +1,10 @@
 import type { ColumnDef } from '@tanstack/react-table'
 import type { User } from '@/lib/types'
 
-export const RECENT_USERS_COLUMNS: ColumnDef<User>[] = [
-  { header: 'Name', accessorKey: 'name' },
-  { header: 'Email', accessorKey: 'email' },
-  { header: 'Role', accessorKey: 'role' },
+type Translator = (key: string, fallback?: string) => string
+
+export const getRecentUsersColumns = (t: Translator): ColumnDef<User>[] => [
+  { header: t('users.table.columns.name', 'Name'), accessorKey: 'name' },
+  { header: t('users.table.columns.email', 'Email'), accessorKey: 'email' },
+  { header: t('users.table.columns.role', 'Role'), accessorKey: 'role' },
 ]

--- a/components/data-table/ColumnVisibilityMenu.tsx
+++ b/components/data-table/ColumnVisibilityMenu.tsx
@@ -3,14 +3,17 @@
 import { Table } from '@tanstack/react-table'
 import { DropdownMenu } from '@/components/ui/DropdownMenu'
 import { Checkbox } from '@/components/ui/Checkbox'
+import { useLocale } from '@/contexts/LocaleProvider'
 
 type ColumnVisibilityMenuProps<TData> = {
   table: Table<TData>
   label?: string
 }
 
-export default function ColumnVisibilityMenu<TData>({ table, label = 'Columns' }: ColumnVisibilityMenuProps<TData>) {
+export default function ColumnVisibilityMenu<TData>({ table, label }: ColumnVisibilityMenuProps<TData>) {
+  const { t } = useLocale()
   const columns = table.getAllLeafColumns()
+  const buttonLabel = label ?? t('common.table.columns', 'Columns')
 
   if (!columns.length) {
     return null
@@ -20,7 +23,7 @@ export default function ColumnVisibilityMenu<TData>({ table, label = 'Columns' }
     <DropdownMenu
       trigger={
         <button type="button" className="btn btn-outline text-sm">
-          {label}
+          {buttonLabel}
         </button>
       }
     >

--- a/components/data-table/DataTable.tsx
+++ b/components/data-table/DataTable.tsx
@@ -5,6 +5,7 @@ import Pagination from './Pagination'
 import DataTableToolbar from './DataTableToolbar'
 import DataTableBody from './DataTableBody'
 import { useConfiguredTable } from './useConfiguredTable'
+import { useLocale } from '@/contexts/LocaleProvider'
 
 type DataTableProps<TData> = {
   columns: ColumnDef<TData, any>[]
@@ -39,6 +40,7 @@ export default function DataTable<TData>({
     searchKeys,
     initialPageSize,
   })
+  const { locale, t } = useLocale()
 
   const showSearch = Boolean(effectiveSearchKeys && effectiveSearchKeys.length > 0)
 
@@ -56,20 +58,25 @@ export default function DataTable<TData>({
       <DataTableBody table={table} />
       <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
         <p className="text-xs text-muted-foreground">
-          Showing
-          {' '}
-          {filteredRowCount ? table.getState().pagination.pageIndex * table.getState().pagination.pageSize + 1 : 0}
-          {' '}
-          -
-          {' '}
-          {filteredRowCount
-            ? Math.min(
-                (table.getState().pagination.pageIndex + 1) * table.getState().pagination.pageSize,
-                filteredRowCount,
-              )
-            : 0}
-          {' '}
-          of {totalRowCount} entries
+          {t('common.table.summary', 'Showing {{from}} – {{to}} of {{total}} entries')
+            .replace(
+              '{{from}}',
+              (filteredRowCount
+                ? table.getState().pagination.pageIndex * table.getState().pagination.pageSize + 1
+                : 0
+              ).toLocaleString(locale)
+            )
+            .replace(
+              '{{to}}',
+              (filteredRowCount
+                ? Math.min(
+                    (table.getState().pagination.pageIndex + 1) * table.getState().pagination.pageSize,
+                    filteredRowCount,
+                  )
+                : 0
+              ).toLocaleString(locale)
+            )
+            .replace('{{total}}', totalRowCount.toLocaleString(locale))}
         </p>
         <Pagination table={table} pageSizeOptions={pageSizeOptions} />
       </div>

--- a/components/data-table/DataTableBody.tsx
+++ b/components/data-table/DataTableBody.tsx
@@ -2,6 +2,7 @@
 
 import { Table, flexRender } from '@tanstack/react-table'
 import EmptyState from '@/components/common/EmptyState'
+import { useLocale } from '@/contexts/LocaleProvider'
 
 type DataTableBodyProps<TData> = {
   table: Table<TData>
@@ -11,12 +12,16 @@ type DataTableBodyProps<TData> = {
 
 export default function DataTableBody<TData>({
   table,
-  emptyStateTitle = 'No results',
-  emptyStateMessage = 'Adjust filters or add new records.',
+  emptyStateTitle,
+  emptyStateMessage,
 }: DataTableBodyProps<TData>) {
   const rowModel = table.getRowModel()
   const hasRows = rowModel.rows.length > 0
   const colSpan = table.getVisibleLeafColumns().length || 1
+  const { t } = useLocale()
+  const resolvedEmptyStateTitle = emptyStateTitle ?? t('common.empty.title', 'No results')
+  const resolvedEmptyStateMessage =
+    emptyStateMessage ?? t('common.table.emptyMessage', 'Adjust filters or add new records.')
 
   return (
     <div className="overflow-x-auto rounded-lg border border-border/50">
@@ -57,7 +62,7 @@ export default function DataTableBody<TData>({
           ) : (
             <tr>
               <td colSpan={colSpan} className="px-6 py-10 text-center">
-                <EmptyState title={emptyStateTitle} message={emptyStateMessage} />
+                <EmptyState title={resolvedEmptyStateTitle} message={resolvedEmptyStateMessage} />
               </td>
             </tr>
           )}

--- a/components/data-table/Pagination.tsx
+++ b/components/data-table/Pagination.tsx
@@ -1,5 +1,6 @@
 'use client'
 import { Table } from '@tanstack/react-table'
+import { useLocale } from '@/contexts/LocaleProvider'
 
 type PaginationProps<T> = {
   table: Table<T>
@@ -7,10 +8,16 @@ type PaginationProps<T> = {
 }
 
 export default function Pagination<T>({ table, pageSizeOptions = [5, 10, 20, 50] }: PaginationProps<T>) {
+  const { locale, t } = useLocale()
+  const currentPage = table.getState().pagination.pageIndex + 1
+  const totalPages = Math.max(table.getPageCount(), 1)
+  const pageLabel = t('common.table.page', 'Page {{current}} of {{total}}')
+    .replace('{{current}}', currentPage.toLocaleString(locale))
+    .replace('{{total}}', totalPages.toLocaleString(locale))
   return (
     <div className="flex w-full flex-col gap-2 sm:flex-row sm:items-center">
       <div className="flex items-center gap-2 text-xs text-muted-foreground">
-        <span>Rows per page</span>
+        <span>{t('common.table.rowsPerPage', 'Rows per page')}</span>
         <select
           className="rounded border border-border/60 bg-transparent px-2 py-1"
           value={table.getState().pagination.pageSize}
@@ -18,7 +25,7 @@ export default function Pagination<T>({ table, pageSizeOptions = [5, 10, 20, 50]
         >
           {pageSizeOptions.map((size) => (
             <option key={size} value={size}>
-              {size}
+              {size.toLocaleString(locale)}
             </option>
           ))}
         </select>
@@ -29,17 +36,17 @@ export default function Pagination<T>({ table, pageSizeOptions = [5, 10, 20, 50]
           onClick={() => table.previousPage()}
           disabled={!table.getCanPreviousPage()}
         >
-          Prev
+          {t('common.table.prev', 'Prev')}
         </button>
         <span className="text-xs text-muted-foreground">
-          Page {table.getState().pagination.pageIndex + 1} of {Math.max(table.getPageCount(), 1)}
+          {pageLabel}
         </span>
         <button
           className="rounded border border-border/60 px-2 py-1 text-xs disabled:opacity-40"
           onClick={() => table.nextPage()}
           disabled={!table.getCanNextPage()}
         >
-          Next
+          {t('common.table.next', 'Next')}
         </button>
       </div>
     </div>

--- a/components/data-table/useConfiguredTable.ts
+++ b/components/data-table/useConfiguredTable.ts
@@ -11,6 +11,7 @@ import {
   getSortedRowModel,
   useReactTable,
 } from '@tanstack/react-table'
+import { useLocale } from '@/contexts/LocaleProvider'
 
 export type UseConfiguredTableProps<TData> = {
   columns: ColumnDef<TData, any>[]
@@ -39,6 +40,7 @@ export function useConfiguredTable<TData>({
   initialPageSize = 10,
 }: UseConfiguredTableProps<TData>): UseConfiguredTableResult<TData> {
   const [filter, setFilter] = useState('')
+  const { t } = useLocale()
 
   const effectiveSearchKeys = useMemo(() => {
     if (searchKeys && searchKeys.length > 0) {
@@ -52,13 +54,19 @@ export function useConfiguredTable<TData>({
 
   const searchPlaceholder = useMemo(() => {
     if (!effectiveSearchKeys || effectiveSearchKeys.length === 0) {
-      return 'Search...'
+      return t('common.table.search.default', 'Search...')
     }
     if (effectiveSearchKeys.length === 1) {
-      return `Search ${effectiveSearchKeys[0]}...`
+      return t('common.table.search.single', 'Search {{field}}...').replace(
+        '{{field}}',
+        effectiveSearchKeys[0]
+      )
     }
-    return `Search ${effectiveSearchKeys.join(' / ')}...`
-  }, [effectiveSearchKeys])
+    return t('common.table.search.multiple', 'Search {{fields}}...').replace(
+      '{{fields}}',
+      effectiveSearchKeys.join(' / ')
+    )
+  }, [effectiveSearchKeys, t])
 
   const globalFilterFn: FilterFn<TData> = useMemo(() => {
     return (row, _columnId, value) => {

--- a/components/forms/AddressSection.tsx
+++ b/components/forms/AddressSection.tsx
@@ -1,7 +1,10 @@
+"use client"
+
 import { FieldErrors, UseFormRegister } from 'react-hook-form'
 import { Input } from '@/components/ui/Input'
 import { Select } from '@/components/ui/Select'
 import { UserFormValues } from '@/lib/validators'
+import { useLocale } from '@/contexts/LocaleProvider'
 
 type AddressSectionProps = {
   register: UseFormRegister<UserFormValues>
@@ -10,12 +13,13 @@ type AddressSectionProps = {
 }
 
 export default function AddressSection({ register, errors, states }: AddressSectionProps) {
+  const { t } = useLocale()
   return (
     <div className="rounded-lg bg-white p-6 shadow dark:bg-gray-800">
-      <h2 className="mb-4 text-lg font-semibold">Address</h2>
+      <h2 className="mb-4 text-lg font-semibold">{t('forms.sections.address', 'Address')}</h2>
       <div className="grid gap-4 md:grid-cols-2">
         <div className="md:col-span-2">
-          <label className="mb-1 block text-sm font-medium">Street Address</label>
+          <label className="mb-1 block text-sm font-medium">{t('forms.fields.address.street', 'Street Address')}</label>
           <Input {...register('address.street')} />
           {errors.address?.street && (
             <p className="mt-1 text-sm text-red-600">{errors.address.street.message}</p>
@@ -23,7 +27,7 @@ export default function AddressSection({ register, errors, states }: AddressSect
         </div>
 
         <div>
-          <label className="mb-1 block text-sm font-medium">City</label>
+          <label className="mb-1 block text-sm font-medium">{t('forms.fields.address.city', 'City')}</label>
           <Input {...register('address.city')} />
           {errors.address?.city && (
             <p className="mt-1 text-sm text-red-600">{errors.address.city.message}</p>
@@ -31,9 +35,9 @@ export default function AddressSection({ register, errors, states }: AddressSect
         </div>
 
         <div>
-          <label className="mb-1 block text-sm font-medium">State</label>
+          <label className="mb-1 block text-sm font-medium">{t('forms.fields.address.state', 'State')}</label>
           <Select {...register('address.state')}>
-            <option value="">Select State</option>
+            <option value="">{t('forms.fields.address.statePlaceholder', 'Select State')}</option>
             {states.map((state) => (
               <option key={state} value={state}>
                 {state}
@@ -46,15 +50,18 @@ export default function AddressSection({ register, errors, states }: AddressSect
         </div>
 
         <div>
-          <label className="mb-1 block text-sm font-medium">ZIP Code</label>
-          <Input {...register('address.zipCode')} placeholder="12345" />
+          <label className="mb-1 block text-sm font-medium">{t('forms.fields.address.zipCode', 'ZIP Code')}</label>
+          <Input
+            {...register('address.zipCode')}
+            placeholder={t('forms.fields.address.zipCodePlaceholder', '12345')}
+          />
           {errors.address?.zipCode && (
             <p className="mt-1 text-sm text-red-600">{errors.address.zipCode.message}</p>
           )}
         </div>
 
         <div>
-          <label className="mb-1 block text-sm font-medium">Country</label>
+          <label className="mb-1 block text-sm font-medium">{t('forms.fields.address.country', 'Country')}</label>
           <Input {...register('address.country')} />
           {errors.address?.country && (
             <p className="mt-1 text-sm text-red-600">{errors.address.country.message}</p>

--- a/components/forms/AgreementSection.tsx
+++ b/components/forms/AgreementSection.tsx
@@ -1,7 +1,10 @@
+"use client"
+
 import { FieldErrors, UseFormRegister } from 'react-hook-form'
 import { Checkbox } from '@/components/ui/Checkbox'
 import { Button } from '@/components/ui/Button'
 import { UserFormValues } from '@/lib/validators'
+import { useLocale } from '@/contexts/LocaleProvider'
 
 type AgreementSectionProps = {
   register: UseFormRegister<UserFormValues>
@@ -9,12 +12,13 @@ type AgreementSectionProps = {
 }
 
 export default function AgreementSection({ register, errors }: AgreementSectionProps) {
+  const { t } = useLocale()
   return (
     <div className="rounded-lg bg-white p-6 shadow dark:bg-gray-800">
       <div className="mb-4 flex items-center gap-2">
         <Checkbox {...register('agreement')} />
         <label className="text-sm">
-          I agree to the Terms of Service and Privacy Policy
+          {t('forms.fields.agreement', 'I agree to the Terms of Service and Privacy Policy')}
         </label>
       </div>
       {errors.agreement && (
@@ -22,7 +26,7 @@ export default function AgreementSection({ register, errors }: AgreementSectionP
       )}
 
       <Button type="submit" className="w-full">
-        Create Account
+        {t('forms.actions.submit', 'Create Account')}
       </Button>
     </div>
   )

--- a/components/forms/BasicInfoSection.tsx
+++ b/components/forms/BasicInfoSection.tsx
@@ -1,8 +1,11 @@
+"use client"
+
 import { ChangeEvent } from 'react'
 import { UseFormRegister, FieldErrors } from 'react-hook-form'
 import { Input } from '@/components/ui/Input'
 import PasswordStrengthMeter from '@/components/forms/PasswordStrengthMeter'
 import { UserFormValues } from '@/lib/validators'
+import { useLocale } from '@/contexts/LocaleProvider'
 
 type BasicInfoSectionProps = {
   register: UseFormRegister<UserFormValues>
@@ -17,6 +20,7 @@ export default function BasicInfoSection({
   passwordStrength,
   onPasswordChange,
 }: BasicInfoSectionProps) {
+  const { t } = useLocale()
   const handlePasswordChange = (event: ChangeEvent<HTMLInputElement>) => {
     onPasswordChange(event.target.value)
   }
@@ -27,22 +31,22 @@ export default function BasicInfoSection({
 
   return (
     <div className="rounded-lg bg-white p-6 shadow dark:bg-gray-800">
-      <h2 className="mb-4 text-lg font-semibold">Basic Information</h2>
+      <h2 className="mb-4 text-lg font-semibold">{t('forms.sections.basicInfo', 'Basic Information')}</h2>
       <div className="grid gap-4 md:grid-cols-2">
         <div>
-          <label className="mb-1 block text-sm font-medium">Full Name</label>
-          <Input placeholder="John Doe" {...register('name')} />
+          <label className="mb-1 block text-sm font-medium">{t('forms.fields.fullName', 'Full Name')}</label>
+          <Input placeholder={t('forms.fields.fullNamePlaceholder', 'John Doe')} {...register('name')} />
           {errors.name && <p className="mt-1 text-sm text-red-600">{errors.name.message}</p>}
         </div>
 
         <div>
-          <label className="mb-1 block text-sm font-medium">Email</label>
-          <Input type="email" placeholder="john@example.com" {...register('email')} />
+          <label className="mb-1 block text-sm font-medium">{t('forms.fields.email', 'Email')}</label>
+          <Input type="email" placeholder={t('forms.fields.emailPlaceholder', 'john@example.com')} {...register('email')} />
           {errors.email && <p className="mt-1 text-sm text-red-600">{errors.email.message}</p>}
         </div>
 
         <div>
-          <label className="mb-1 block text-sm font-medium">Password</label>
+          <label className="mb-1 block text-sm font-medium">{t('forms.fields.password', 'Password')}</label>
           <Input type="password" {...passwordField} />
           {errors.password && (
             <p className="mt-1 text-sm text-red-600">{errors.password.message}</p>
@@ -51,7 +55,7 @@ export default function BasicInfoSection({
         </div>
 
         <div>
-          <label className="mb-1 block text-sm font-medium">Confirm Password</label>
+          <label className="mb-1 block text-sm font-medium">{t('forms.fields.confirmPassword', 'Confirm Password')}</label>
           <Input type="password" {...register('confirmPassword')} />
           {errors.confirmPassword && (
             <p className="mt-1 text-sm text-red-600">{errors.confirmPassword.message}</p>
@@ -59,13 +63,13 @@ export default function BasicInfoSection({
         </div>
 
         <div>
-          <label className="mb-1 block text-sm font-medium">Phone</label>
-          <Input type="tel" placeholder="+1234567890" {...register('phone')} />
+          <label className="mb-1 block text-sm font-medium">{t('forms.fields.phone', 'Phone')}</label>
+          <Input type="tel" placeholder={t('forms.fields.phonePlaceholder', '+1234567890')} {...register('phone')} />
           {errors.phone && <p className="mt-1 text-sm text-red-600">{errors.phone.message}</p>}
         </div>
 
         <div>
-          <label className="mb-1 block text-sm font-medium">Date of Birth</label>
+          <label className="mb-1 block text-sm font-medium">{t('forms.fields.dateOfBirth', 'Date of Birth')}</label>
           <Input type="date" {...register('dateOfBirth')} />
           {errors.dateOfBirth && (
             <p className="mt-1 text-sm text-red-600">{errors.dateOfBirth.message}</p>

--- a/components/forms/NotificationsSection.tsx
+++ b/components/forms/NotificationsSection.tsx
@@ -1,28 +1,32 @@
+"use client"
+
 import { UseFormRegister } from 'react-hook-form'
 import { Switch } from '@/components/ui/Switch'
 import { UserFormValues } from '@/lib/validators'
+import { useLocale } from '@/contexts/LocaleProvider'
 
 type NotificationsSectionProps = {
   register: UseFormRegister<UserFormValues>
 }
 
 export default function NotificationsSection({ register }: NotificationsSectionProps) {
+  const { t } = useLocale()
   return (
     <div className="rounded-lg bg-white p-6 shadow dark:bg-gray-800">
-      <h2 className="mb-4 text-lg font-semibold">Notification Preferences</h2>
+      <h2 className="mb-4 text-lg font-semibold">{t('forms.sections.notifications', 'Notification Preferences')}</h2>
       <div className="space-y-4">
         <div className="flex items-center justify-between">
-          <label className="text-sm font-medium">Email Notifications</label>
+          <label className="text-sm font-medium">{t('forms.fields.notifications.email', 'Email Notifications')}</label>
           <Switch {...register('notifications.email')} />
         </div>
 
         <div className="flex items-center justify-between">
-          <label className="text-sm font-medium">SMS Notifications</label>
+          <label className="text-sm font-medium">{t('forms.fields.notifications.sms', 'SMS Notifications')}</label>
           <Switch {...register('notifications.sms')} />
         </div>
 
         <div className="flex items-center justify-between">
-          <label className="text-sm font-medium">Push Notifications</label>
+          <label className="text-sm font-medium">{t('forms.fields.notifications.push', 'Push Notifications')}</label>
           <Switch {...register('notifications.push')} />
         </div>
       </div>

--- a/components/forms/PasswordStrengthMeter.tsx
+++ b/components/forms/PasswordStrengthMeter.tsx
@@ -1,10 +1,13 @@
 'use client'
 
+import { useLocale } from '@/contexts/LocaleProvider'
+
 type Props = {
   strength: number
 }
 
 export default function PasswordStrengthMeter({ strength }: Props) {
+  const { t } = useLocale()
   const getColor = (value: number) => {
     if (value <= 2) return 'bg-red-500'
     if (value <= 3) return 'bg-yellow-500'
@@ -13,11 +16,16 @@ export default function PasswordStrengthMeter({ strength }: Props) {
   }
 
   const getMessage = (value: number) => {
-    if (value <= 2) return 'Weak'
-    if (value <= 3) return 'Fair'
-    if (value <= 4) return 'Good'
-    return 'Strong'
+    if (value <= 2) return t('common.password.levels.weak', 'Weak')
+    if (value <= 3) return t('common.password.levels.fair', 'Fair')
+    if (value <= 4) return t('common.password.levels.good', 'Good')
+    return t('common.password.levels.strong', 'Strong')
   }
+
+  const message = t('common.password.label', 'Password strength: {{level}}').replace(
+    '{{level}}',
+    getMessage(strength)
+  )
 
   return (
     <div className="mt-1">
@@ -30,7 +38,7 @@ export default function PasswordStrengthMeter({ strength }: Props) {
         ))}
       </div>
       <p className={`mt-1 text-xs ${getColor(strength).replace('bg-', 'text-')}`}>
-        Password strength: {getMessage(strength)}
+        {message}
       </p>
     </div>
   )

--- a/components/forms/RoleStatusSection.tsx
+++ b/components/forms/RoleStatusSection.tsx
@@ -1,7 +1,10 @@
+"use client"
+
 import { FieldErrors, UseFormRegister } from 'react-hook-form'
 import { Select } from '@/components/ui/Select'
 import { Checkbox } from '@/components/ui/Checkbox'
 import { UserFormValues } from '@/lib/validators'
+import { useLocale } from '@/contexts/LocaleProvider'
 
 type RoleStatusSectionProps = {
   register: UseFormRegister<UserFormValues>
@@ -9,25 +12,26 @@ type RoleStatusSectionProps = {
 }
 
 export default function RoleStatusSection({ register, errors }: RoleStatusSectionProps) {
+  const { t } = useLocale()
   return (
     <div className="rounded-lg bg-white p-6 shadow dark:bg-gray-800">
-      <h2 className="mb-4 text-lg font-semibold">Role and Status</h2>
+      <h2 className="mb-4 text-lg font-semibold">{t('forms.sections.roleStatus', 'Role and Status')}</h2>
       <div className="grid gap-4 md:grid-cols-2">
         <div>
-          <label className="mb-1 block text-sm font-medium">Role</label>
+          <label className="mb-1 block text-sm font-medium">{t('forms.fields.role', 'Role')}</label>
           <Select {...register('role')}>
-            <option value="admin">Admin</option>
-            <option value="editor">Editor</option>
-            <option value="viewer">Viewer</option>
+            <option value="admin">{t('forms.roleOptions.admin', 'Admin')}</option>
+            <option value="editor">{t('forms.roleOptions.editor', 'Editor')}</option>
+            <option value="viewer">{t('forms.roleOptions.viewer', 'Viewer')}</option>
           </Select>
           {errors.role && <p className="mt-1 text-sm text-red-600">{errors.role.message}</p>}
         </div>
 
         <div>
-          <label className="mb-1 block text-sm font-medium">Status</label>
+          <label className="mb-1 block text-sm font-medium">{t('forms.fields.status', 'Status')}</label>
           <div className="flex items-center gap-2">
             <Checkbox {...register('active')} />
-            <span>Active Account</span>
+            <span>{t('common.status.activeAccount', 'Active Account')}</span>
           </div>
         </div>
       </div>

--- a/components/forms/SkillsSelector.tsx
+++ b/components/forms/SkillsSelector.tsx
@@ -1,6 +1,9 @@
+"use client"
+
 import { FieldErrors, UseFormRegister } from 'react-hook-form'
 import { Checkbox } from '@/components/ui/Checkbox'
 import { UserFormValues } from '@/lib/validators'
+import { useLocale } from '@/contexts/LocaleProvider'
 
 type SkillsSelectorProps = {
   skills: readonly string[]
@@ -15,9 +18,10 @@ export default function SkillsSelector({
   errors,
   isSkillSelected,
 }: SkillsSelectorProps) {
+  const { t } = useLocale()
   return (
     <div className="rounded-lg bg-white p-6 shadow dark:bg-gray-800">
-      <h2 className="mb-4 text-lg font-semibold">Skills</h2>
+      <h2 className="mb-4 text-lg font-semibold">{t('forms.sections.skills', 'Skills')}</h2>
       <div className="space-y-4">
         <div className="flex flex-wrap gap-2">
           {skills.map((skill) => {

--- a/components/layout/Header.tsx
+++ b/components/layout/Header.tsx
@@ -4,10 +4,12 @@ import { useSidebar } from '@/contexts/SidebarProvider'
 import AvatarMenu from '../common/AvatarMenu'
 import LocaleSwitcher from '../common/LocaleSwitcher'
 import { useTheme } from 'next-themes'
+import { useLocale } from '@/contexts/LocaleProvider'
 
 export default function Header() {
   const { toggle } = useSidebar()
   const { theme, setTheme } = useTheme()
+  const { t } = useLocale()
   const isDark = theme === 'dark'
   return (
     <header className="sticky top-0 z-40 w-full border-b bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60">
@@ -16,18 +18,20 @@ export default function Header() {
           <button
             className="inline-flex items-center justify-center rounded-md p-2 hover:bg-accent hover:text-accent-foreground md:hidden"
             onClick={toggle}
-            aria-label="Toggle sidebar"
+            aria-label={t('header.actions.toggleSidebar', 'Toggle sidebar')}
           >
             <Menu className="h-5 w-5" />
           </button>
-          <span className="hidden text-sm font-semibold text-muted-foreground md:block">Admin Dashboard</span>
+          <span className="hidden text-sm font-semibold text-muted-foreground md:block">
+            {t('header.title', 'Admin Dashboard')}
+          </span>
         </div>
         <div className="flex items-center gap-3">
           <LocaleSwitcher />
           <button
             onClick={() => setTheme(isDark ? 'light' : 'dark')}
             className="inline-flex items-center justify-center rounded-md p-2 hover:bg-accent hover:text-accent-foreground"
-            aria-label="Toggle theme"
+            aria-label={t('header.actions.toggleTheme', 'Toggle theme')}
           >
             {isDark ? <Sun className="h-5 w-5" /> : <Moon className="h-5 w-5" />}
           </button>

--- a/locales/en.ts
+++ b/locales/en.ts
@@ -14,9 +14,221 @@ const en = {
       logout: 'Logout',
     },
   },
+  header: {
+    title: 'Admin Dashboard',
+    actions: {
+      toggleSidebar: 'Toggle sidebar',
+      toggleTheme: 'Toggle theme',
+      toggleAccountMenu: 'Toggle account menu',
+    },
+  },
+  common: {
+    loading: {
+      interface: 'Loading interface…',
+    },
+    errors: {
+      generic: 'Something went wrong',
+    },
+    empty: {
+      title: 'No results',
+      description: 'No records found',
+      dashboard: 'No dashboard data available',
+      revenueTrend: 'No revenue trend data available',
+      revenueByRegion: 'No regional revenue data available',
+      segments: 'No user distribution data available',
+      performance: 'No performance metrics available',
+      activity: 'No recent activity recorded',
+      users: 'No users found',
+    },
+    buttons: {
+      tryAgain: 'Try again',
+      viewAll: 'View All',
+      cancel: 'Cancel',
+      confirm: 'Confirm',
+      edit: 'Edit',
+      delete: 'Delete',
+      save: 'Save',
+    },
+    units: {
+      minutesShort: 'min',
+    },
+    status: {
+      active: 'Active',
+      activeAccount: 'Active Account',
+      yes: 'Yes',
+      no: 'No',
+    },
+    table: {
+      summary: 'Showing {{from}} – {{to}} of {{total}} entries',
+      rowsPerPage: 'Rows per page',
+      page: 'Page {{current}} of {{total}}',
+      prev: 'Prev',
+      next: 'Next',
+      columns: 'Columns',
+      emptyMessage: 'Adjust filters or add new records.',
+      search: {
+        default: 'Search...',
+        single: 'Search {{field}}...',
+        multiple: 'Search {{fields}}...',
+      },
+    },
+    modals: {
+      deleteUserTitle: 'Delete user?',
+    },
+    messages: {
+      formSubmitted: 'Form submitted successfully!',
+      settingsSaved: 'Settings saved',
+      usersErrorTitle: 'Failed to load users',
+      usersErrorMessage: 'Please try again later.',
+      usersEmptyTitle: 'No users yet',
+      usersEmptyMessage: 'Invite your colleagues to get started.',
+    },
+    password: {
+      label: 'Password strength: {{level}}',
+      levels: {
+        weak: 'Weak',
+        fair: 'Fair',
+        good: 'Good',
+        strong: 'Strong',
+      },
+    },
+  },
   dashboard: {
+    page: {
+      title: 'Dashboard Overview',
+      description: "Welcome back! Here's a summary of your business metrics.",
+    },
+    errors: {
+      stats: 'Failed to load dashboard data',
+      users: 'Failed to load user data',
+    },
+    stats: {
+      totalUsers: 'Total Users',
+      vsLastMonth: 'vs last month',
+      activeUsers: 'Active Users',
+      ofTotalUsers: 'of total users',
+      revenue: 'Revenue',
+      avgSession: 'Avg. Session',
+      satisfaction: 'Satisfaction',
+      vsLastSurvey: 'vs last survey',
+    },
+    revenue: {
+      trendTitle: 'Revenue Trend',
+      regionTitle: 'Revenue by Region',
+      datasetLabel: 'Revenue',
+    },
     segments: {
+      title: 'Customer Segments',
       share: 'Share of active users',
+    },
+    performance: {
+      title: 'Performance Snapshot',
+      pageLoad: 'Page Load',
+      errorRate: 'Error Rate',
+      improvement: 'Improvement',
+      uptime: 'Uptime',
+      lastThirtyDays: 'Last 30 days',
+    },
+    recentUsers: {
+      title: 'Recent Users',
+    },
+    recentActivity: {
+      title: 'Recent Activity',
+    },
+  },
+  users: {
+    page: {
+      title: 'Users',
+      description: 'Manage your team members and their access levels.',
+    },
+    table: {
+      columns: {
+        name: 'Name',
+        email: 'Email',
+        role: 'Role',
+        active: 'Active',
+        actions: 'Actions',
+      },
+      active: {
+        yes: 'Yes',
+        no: 'No',
+      },
+    },
+  },
+  forms: {
+    page: {
+      title: 'Advanced User Registration',
+      description: 'Collect detailed account information and configure preferences at once.',
+    },
+    sections: {
+      basicInfo: 'Basic Information',
+      roleStatus: 'Role and Status',
+      skills: 'Skills',
+      address: 'Address',
+      notifications: 'Notification Preferences',
+      agreement: 'Agreement',
+    },
+    fields: {
+      fullName: 'Full Name',
+      fullNamePlaceholder: 'John Doe',
+      email: 'Email',
+      emailPlaceholder: 'john@example.com',
+      password: 'Password',
+      confirmPassword: 'Confirm Password',
+      phone: 'Phone',
+      phonePlaceholder: '+1234567890',
+      dateOfBirth: 'Date of Birth',
+      role: 'Role',
+      status: 'Status',
+      address: {
+        street: 'Street Address',
+        city: 'City',
+        state: 'State',
+        statePlaceholder: 'Select State',
+        zipCode: 'ZIP Code',
+        zipCodePlaceholder: '12345',
+        country: 'Country',
+      },
+      notifications: {
+        email: 'Email Notifications',
+        sms: 'SMS Notifications',
+        push: 'Push Notifications',
+      },
+      agreement: 'I agree to the Terms of Service and Privacy Policy',
+    },
+    roleOptions: {
+      admin: 'Admin',
+      editor: 'Editor',
+      viewer: 'Viewer',
+    },
+    actions: {
+      submit: 'Create Account',
+    },
+  },
+  settings: {
+    page: {
+      title: 'Settings',
+      description: 'Update your profile information and notification preferences.',
+    },
+    fields: {
+      namePlaceholder: 'Name',
+      emailPlaceholder: 'Email',
+    },
+  },
+  blank: {
+    page: {
+      title: 'Blank Page',
+      description: 'Start from a clean slate.',
+      content: 'Customize this page by adding components or data visualisations.',
+    },
+  },
+  system: {
+    error: {
+      title: 'Something went wrong',
+    },
+    notFound: {
+      title: '404 - Page Not Found',
+      description: 'The page you are looking for does not exist.',
     },
   },
 }

--- a/locales/es.ts
+++ b/locales/es.ts
@@ -14,9 +14,221 @@ const es = {
       logout: 'Cerrar sesión',
     },
   },
+  header: {
+    title: 'Panel de administración',
+    actions: {
+      toggleSidebar: 'Alternar barra lateral',
+      toggleTheme: 'Cambiar tema',
+      toggleAccountMenu: 'Alternar menú de cuenta',
+    },
+  },
+  common: {
+    loading: {
+      interface: 'Cargando interfaz…',
+    },
+    errors: {
+      generic: 'Algo salió mal',
+    },
+    empty: {
+      title: 'Sin resultados',
+      description: 'No se encontraron registros',
+      dashboard: 'No hay datos del panel disponibles',
+      revenueTrend: 'No hay datos de tendencia de ingresos disponibles',
+      revenueByRegion: 'No hay datos de ingresos por región disponibles',
+      segments: 'No hay datos de distribución de usuarios disponibles',
+      performance: 'No hay métricas de rendimiento disponibles',
+      activity: 'No se registró actividad reciente',
+      users: 'No se encontraron usuarios',
+    },
+    buttons: {
+      tryAgain: 'Intentar de nuevo',
+      viewAll: 'Ver todo',
+      cancel: 'Cancelar',
+      confirm: 'Confirmar',
+      edit: 'Editar',
+      delete: 'Eliminar',
+      save: 'Guardar',
+    },
+    units: {
+      minutesShort: 'min',
+    },
+    status: {
+      active: 'Activo',
+      activeAccount: 'Cuenta activa',
+      yes: 'Sí',
+      no: 'No',
+    },
+    table: {
+      summary: 'Mostrando {{from}}–{{to}} de {{total}} registros',
+      rowsPerPage: 'Filas por página',
+      page: 'Página {{current}} de {{total}}',
+      prev: 'Anterior',
+      next: 'Siguiente',
+      columns: 'Columnas',
+      emptyMessage: 'Ajusta los filtros o agrega nuevos registros.',
+      search: {
+        default: 'Buscar...',
+        single: 'Buscar {{field}}...',
+        multiple: 'Buscar {{fields}}...',
+      },
+    },
+    modals: {
+      deleteUserTitle: '¿Eliminar usuario?',
+    },
+    messages: {
+      formSubmitted: '¡Formulario enviado con éxito!',
+      settingsSaved: 'Configuración guardada',
+      usersErrorTitle: 'No se pudieron cargar los usuarios',
+      usersErrorMessage: 'Vuelve a intentarlo más tarde.',
+      usersEmptyTitle: 'Aún no hay usuarios',
+      usersEmptyMessage: 'Invita a tus colegas para comenzar.',
+    },
+    password: {
+      label: 'Fortaleza de la contraseña: {{level}}',
+      levels: {
+        weak: 'Débil',
+        fair: 'Regular',
+        good: 'Buena',
+        strong: 'Fuerte',
+      },
+    },
+  },
   dashboard: {
+    page: {
+      title: 'Resumen del panel',
+      description: '¡Bienvenido de nuevo! Aquí tienes un resumen de tus métricas de negocio.',
+    },
+    errors: {
+      stats: 'Error al cargar los datos del panel',
+      users: 'Error al cargar los datos de usuarios',
+    },
+    stats: {
+      totalUsers: 'Usuarios totales',
+      vsLastMonth: 'vs. el mes pasado',
+      activeUsers: 'Usuarios activos',
+      ofTotalUsers: 'del total de usuarios',
+      revenue: 'Ingresos',
+      avgSession: 'Sesión prom.',
+      satisfaction: 'Satisfacción',
+      vsLastSurvey: 'vs. la última encuesta',
+    },
+    revenue: {
+      trendTitle: 'Tendencia de ingresos',
+      regionTitle: 'Ingresos por región',
+      datasetLabel: 'Ingresos',
+    },
     segments: {
+      title: 'Segmentos de clientes',
       share: 'Participación de usuarios activos',
+    },
+    performance: {
+      title: 'Instantánea de rendimiento',
+      pageLoad: 'Carga de página',
+      errorRate: 'Tasa de errores',
+      improvement: 'Mejora',
+      uptime: 'Disponibilidad',
+      lastThirtyDays: 'Últimos 30 días',
+    },
+    recentUsers: {
+      title: 'Usuarios recientes',
+    },
+    recentActivity: {
+      title: 'Actividad reciente',
+    },
+  },
+  users: {
+    page: {
+      title: 'Usuarios',
+      description: 'Administra a los miembros del equipo y sus niveles de acceso.',
+    },
+    table: {
+      columns: {
+        name: 'Nombre',
+        email: 'Correo electrónico',
+        role: 'Rol',
+        active: 'Activo',
+        actions: 'Acciones',
+      },
+      active: {
+        yes: 'Sí',
+        no: 'No',
+      },
+    },
+  },
+  forms: {
+    page: {
+      title: 'Registro avanzado de usuarios',
+      description: 'Recopila información detallada de la cuenta y configura preferencias a la vez.',
+    },
+    sections: {
+      basicInfo: 'Información básica',
+      roleStatus: 'Rol y estado',
+      skills: 'Habilidades',
+      address: 'Dirección',
+      notifications: 'Preferencias de notificación',
+      agreement: 'Acuerdo',
+    },
+    fields: {
+      fullName: 'Nombre completo',
+      fullNamePlaceholder: 'Juan Pérez',
+      email: 'Correo electrónico',
+      emailPlaceholder: 'juan@example.com',
+      password: 'Contraseña',
+      confirmPassword: 'Confirmar contraseña',
+      phone: 'Teléfono',
+      phonePlaceholder: '+34123456789',
+      dateOfBirth: 'Fecha de nacimiento',
+      role: 'Rol',
+      status: 'Estado',
+      address: {
+        street: 'Dirección',
+        city: 'Ciudad',
+        state: 'Estado',
+        statePlaceholder: 'Selecciona un estado',
+        zipCode: 'Código postal',
+        zipCodePlaceholder: '12345',
+        country: 'País',
+      },
+      notifications: {
+        email: 'Notificaciones por correo',
+        sms: 'Notificaciones por SMS',
+        push: 'Notificaciones push',
+      },
+      agreement: 'Acepto los Términos del servicio y la Política de privacidad',
+    },
+    roleOptions: {
+      admin: 'Administrador',
+      editor: 'Editor',
+      viewer: 'Visualizador',
+    },
+    actions: {
+      submit: 'Crear cuenta',
+    },
+  },
+  settings: {
+    page: {
+      title: 'Configuración',
+      description: 'Actualiza la información de tu perfil y las preferencias de notificación.',
+    },
+    fields: {
+      namePlaceholder: 'Nombre',
+      emailPlaceholder: 'Correo electrónico',
+    },
+  },
+  blank: {
+    page: {
+      title: 'Página en blanco',
+      description: 'Comienza desde cero.',
+      content: 'Personaliza esta página añadiendo componentes o visualizaciones de datos.',
+    },
+  },
+  system: {
+    error: {
+      title: 'Algo salió mal',
+    },
+    notFound: {
+      title: '404 - Página no encontrada',
+      description: 'La página que buscas no existe.',
     },
   },
 }

--- a/locales/fr.ts
+++ b/locales/fr.ts
@@ -10,13 +10,225 @@ const fr = {
       users: 'Utilisateurs',
       forms: 'Formulaires',
       settings: 'Paramètres',
-      blank: 'Page vierge',
+      blank: 'Page vide',
       logout: 'Se déconnecter',
     },
   },
+  header: {
+    title: 'Tableau de bord administrateur',
+    actions: {
+      toggleSidebar: 'Basculer la barre latérale',
+      toggleTheme: 'Changer de thème',
+      toggleAccountMenu: 'Basculer le menu du compte',
+    },
+  },
+  common: {
+    loading: {
+      interface: "Chargement de l'interface…",
+    },
+    errors: {
+      generic: 'Une erreur est survenue',
+    },
+    empty: {
+      title: 'Aucun résultat',
+      description: 'Aucun enregistrement trouvé',
+      dashboard: 'Aucune donnée du tableau de bord disponible',
+      revenueTrend: 'Aucune donnée de tendance des revenus disponible',
+      revenueByRegion: 'Aucune donnée de revenus par région disponible',
+      segments: 'Aucune donnée de répartition des utilisateurs disponible',
+      performance: 'Aucune mesure de performance disponible',
+      activity: 'Aucune activité récente enregistrée',
+      users: 'Aucun utilisateur trouvé',
+    },
+    buttons: {
+      tryAgain: 'Réessayer',
+      viewAll: 'Voir tout',
+      cancel: 'Annuler',
+      confirm: 'Confirmer',
+      edit: 'Modifier',
+      delete: 'Supprimer',
+      save: 'Enregistrer',
+    },
+    units: {
+      minutesShort: 'min',
+    },
+    status: {
+      active: 'Actif',
+      activeAccount: 'Compte actif',
+      yes: 'Oui',
+      no: 'Non',
+    },
+    table: {
+      summary: 'Affichage de {{from}}–{{to}} sur {{total}} entrées',
+      rowsPerPage: 'Lignes par page',
+      page: 'Page {{current}} sur {{total}}',
+      prev: 'Précédent',
+      next: 'Suivant',
+      columns: 'Colonnes',
+      emptyMessage: 'Ajustez les filtres ou ajoutez de nouveaux enregistrements.',
+      search: {
+        default: 'Rechercher...',
+        single: 'Rechercher {{field}}...',
+        multiple: 'Rechercher {{fields}}...',
+      },
+    },
+    modals: {
+      deleteUserTitle: 'Supprimer l’utilisateur ?',
+    },
+    messages: {
+      formSubmitted: 'Formulaire envoyé avec succès !',
+      settingsSaved: 'Paramètres enregistrés',
+      usersErrorTitle: 'Impossible de charger les utilisateurs',
+      usersErrorMessage: 'Veuillez réessayer plus tard.',
+      usersEmptyTitle: 'Pas encore d’utilisateurs',
+      usersEmptyMessage: 'Invitez vos collègues pour commencer.',
+    },
+    password: {
+      label: 'Solidité du mot de passe : {{level}}',
+      levels: {
+        weak: 'Faible',
+        fair: 'Moyen',
+        good: 'Bon',
+        strong: 'Excellent',
+      },
+    },
+  },
   dashboard: {
+    page: {
+      title: 'Vue d’ensemble du tableau de bord',
+      description: 'Content de vous revoir ! Voici un résumé de vos indicateurs métier.',
+    },
+    errors: {
+      stats: 'Échec du chargement des données du tableau de bord',
+      users: 'Échec du chargement des données utilisateurs',
+    },
+    stats: {
+      totalUsers: 'Utilisateurs au total',
+      vsLastMonth: 'par rapport au mois dernier',
+      activeUsers: 'Utilisateurs actifs',
+      ofTotalUsers: 'du total des utilisateurs',
+      revenue: 'Revenus',
+      avgSession: 'Session moy.',
+      satisfaction: 'Satisfaction',
+      vsLastSurvey: 'par rapport à la dernière enquête',
+    },
+    revenue: {
+      trendTitle: 'Tendance des revenus',
+      regionTitle: 'Revenus par région',
+      datasetLabel: 'Revenus',
+    },
     segments: {
+      title: 'Segments clients',
       share: 'Part des utilisateurs actifs',
+    },
+    performance: {
+      title: 'Instantané des performances',
+      pageLoad: 'Chargement de page',
+      errorRate: "Taux d'erreur",
+      improvement: 'Amélioration',
+      uptime: 'Disponibilité',
+      lastThirtyDays: '30 derniers jours',
+    },
+    recentUsers: {
+      title: 'Utilisateurs récents',
+    },
+    recentActivity: {
+      title: 'Activité récente',
+    },
+  },
+  users: {
+    page: {
+      title: 'Utilisateurs',
+      description: 'Gérez les membres de votre équipe et leurs niveaux d’accès.',
+    },
+    table: {
+      columns: {
+        name: 'Nom',
+        email: 'E-mail',
+        role: 'Rôle',
+        active: 'Actif',
+        actions: 'Actions',
+      },
+      active: {
+        yes: 'Oui',
+        no: 'Non',
+      },
+    },
+  },
+  forms: {
+    page: {
+      title: "Inscription avancée d'utilisateurs",
+      description: 'Collectez des informations détaillées sur le compte et configurez les préférences en une seule fois.',
+    },
+    sections: {
+      basicInfo: 'Informations de base',
+      roleStatus: 'Rôle et statut',
+      skills: 'Compétences',
+      address: 'Adresse',
+      notifications: 'Préférences de notification',
+      agreement: 'Accord',
+    },
+    fields: {
+      fullName: 'Nom complet',
+      fullNamePlaceholder: 'Jean Dupont',
+      email: 'E-mail',
+      emailPlaceholder: 'jean@example.com',
+      password: 'Mot de passe',
+      confirmPassword: 'Confirmer le mot de passe',
+      phone: 'Téléphone',
+      phonePlaceholder: '+33123456789',
+      dateOfBirth: 'Date de naissance',
+      role: 'Rôle',
+      status: 'Statut',
+      address: {
+        street: 'Adresse',
+        city: 'Ville',
+        state: 'État',
+        statePlaceholder: 'Sélectionnez un État',
+        zipCode: 'Code postal',
+        zipCodePlaceholder: '12345',
+        country: 'Pays',
+      },
+      notifications: {
+        email: 'Notifications par e-mail',
+        sms: 'Notifications par SMS',
+        push: 'Notifications push',
+      },
+      agreement: "J'accepte les Conditions d'utilisation et la Politique de confidentialité",
+    },
+    roleOptions: {
+      admin: 'Administrateur',
+      editor: 'Éditeur',
+      viewer: 'Lecteur',
+    },
+    actions: {
+      submit: 'Créer un compte',
+    },
+  },
+  settings: {
+    page: {
+      title: 'Paramètres',
+      description: 'Mettez à jour les informations de votre profil et vos préférences de notification.',
+    },
+    fields: {
+      namePlaceholder: 'Nom',
+      emailPlaceholder: 'E-mail',
+    },
+  },
+  blank: {
+    page: {
+      title: 'Page vide',
+      description: 'Repartez de zéro.',
+      content: 'Personnalisez cette page en ajoutant des composants ou des visualisations de données.',
+    },
+  },
+  system: {
+    error: {
+      title: 'Une erreur est survenue',
+    },
+    notFound: {
+      title: '404 - Page introuvable',
+      description: "La page que vous recherchez n'existe pas.",
     },
   },
 }

--- a/locales/ru.ts
+++ b/locales/ru.ts
@@ -10,13 +10,225 @@ const ru = {
       users: 'Пользователи',
       forms: 'Формы',
       settings: 'Настройки',
-      blank: 'Чистая страница',
+      blank: 'Пустая страница',
       logout: 'Выйти',
     },
   },
+  header: {
+    title: 'Админ-панель',
+    actions: {
+      toggleSidebar: 'Переключить боковую панель',
+      toggleTheme: 'Переключить тему',
+      toggleAccountMenu: 'Переключить меню аккаунта',
+    },
+  },
+  common: {
+    loading: {
+      interface: 'Загрузка интерфейса…',
+    },
+    errors: {
+      generic: 'Что-то пошло не так',
+    },
+    empty: {
+      title: 'Нет результатов',
+      description: 'Записи не найдены',
+      dashboard: 'Данные для панели недоступны',
+      revenueTrend: 'Нет данных о динамике дохода',
+      revenueByRegion: 'Нет данных о доходе по регионам',
+      segments: 'Нет данных о распределении пользователей',
+      performance: 'Нет данных о показателях эффективности',
+      activity: 'Последняя активность отсутствует',
+      users: 'Пользователи не найдены',
+    },
+    buttons: {
+      tryAgain: 'Повторить попытку',
+      viewAll: 'Показать все',
+      cancel: 'Отмена',
+      confirm: 'Подтвердить',
+      edit: 'Редактировать',
+      delete: 'Удалить',
+      save: 'Сохранить',
+    },
+    units: {
+      minutesShort: 'мин',
+    },
+    status: {
+      active: 'Активен',
+      activeAccount: 'Активный аккаунт',
+      yes: 'Да',
+      no: 'Нет',
+    },
+    table: {
+      summary: 'Показаны записи {{from}}–{{to}} из {{total}}',
+      rowsPerPage: 'Строк на странице',
+      page: 'Страница {{current}} из {{total}}',
+      prev: 'Назад',
+      next: 'Вперёд',
+      columns: 'Столбцы',
+      emptyMessage: 'Измените фильтры или добавьте новые записи.',
+      search: {
+        default: 'Поиск...',
+        single: 'Поиск по {{field}}...',
+        multiple: 'Поиск по {{fields}}...',
+      },
+    },
+    modals: {
+      deleteUserTitle: 'Удалить пользователя?',
+    },
+    messages: {
+      formSubmitted: 'Форма успешно отправлена!',
+      settingsSaved: 'Настройки сохранены',
+      usersErrorTitle: 'Не удалось загрузить пользователей',
+      usersErrorMessage: 'Попробуйте ещё раз позже.',
+      usersEmptyTitle: 'Пока нет пользователей',
+      usersEmptyMessage: 'Пригласите коллег, чтобы начать работу.',
+    },
+    password: {
+      label: 'Надёжность пароля: {{level}}',
+      levels: {
+        weak: 'Слабый',
+        fair: 'Средний',
+        good: 'Хороший',
+        strong: 'Отличный',
+      },
+    },
+  },
   dashboard: {
+    page: {
+      title: 'Обзор панели',
+      description: 'С возвращением! Краткое резюме показателей вашего бизнеса.',
+    },
+    errors: {
+      stats: 'Не удалось загрузить данные панели',
+      users: 'Не удалось загрузить данные пользователей',
+    },
+    stats: {
+      totalUsers: 'Всего пользователей',
+      vsLastMonth: 'к прошлому месяцу',
+      activeUsers: 'Активные пользователи',
+      ofTotalUsers: 'от общего числа',
+      revenue: 'Доход',
+      avgSession: 'Средняя сессия',
+      satisfaction: 'Удовлетворённость',
+      vsLastSurvey: 'к прошлому опросу',
+    },
+    revenue: {
+      trendTitle: 'Динамика дохода',
+      regionTitle: 'Доход по регионам',
+      datasetLabel: 'Доход',
+    },
     segments: {
+      title: 'Сегменты клиентов',
       share: 'Доля активных пользователей',
+    },
+    performance: {
+      title: 'Сводка по эффективности',
+      pageLoad: 'Загрузка страницы',
+      errorRate: 'Доля ошибок',
+      improvement: 'Улучшение',
+      uptime: 'Аптайм',
+      lastThirtyDays: 'Последние 30 дней',
+    },
+    recentUsers: {
+      title: 'Недавние пользователи',
+    },
+    recentActivity: {
+      title: 'Недавняя активность',
+    },
+  },
+  users: {
+    page: {
+      title: 'Пользователи',
+      description: 'Управляйте участниками команды и их уровнями доступа.',
+    },
+    table: {
+      columns: {
+        name: 'Имя',
+        email: 'Email',
+        role: 'Роль',
+        active: 'Активен',
+        actions: 'Действия',
+      },
+      active: {
+        yes: 'Да',
+        no: 'Нет',
+      },
+    },
+  },
+  forms: {
+    page: {
+      title: 'Расширенная регистрация пользователя',
+      description: 'Соберите расширенные данные аккаунта и настройте предпочтения за один раз.',
+    },
+    sections: {
+      basicInfo: 'Основная информация',
+      roleStatus: 'Роль и статус',
+      skills: 'Навыки',
+      address: 'Адрес',
+      notifications: 'Настройки уведомлений',
+      agreement: 'Согласие',
+    },
+    fields: {
+      fullName: 'Полное имя',
+      fullNamePlaceholder: 'Иван Иванов',
+      email: 'Email',
+      emailPlaceholder: 'ivan@example.com',
+      password: 'Пароль',
+      confirmPassword: 'Подтверждение пароля',
+      phone: 'Телефон',
+      phonePlaceholder: '+79991234567',
+      dateOfBirth: 'Дата рождения',
+      role: 'Роль',
+      status: 'Статус',
+      address: {
+        street: 'Улица и дом',
+        city: 'Город',
+        state: 'Штат',
+        statePlaceholder: 'Выберите штат',
+        zipCode: 'Почтовый индекс',
+        zipCodePlaceholder: '12345',
+        country: 'Страна',
+      },
+      notifications: {
+        email: 'Email-уведомления',
+        sms: 'SMS-уведомления',
+        push: 'Push-уведомления',
+      },
+      agreement: 'Я принимаю Условия использования и Политику конфиденциальности',
+    },
+    roleOptions: {
+      admin: 'Администратор',
+      editor: 'Редактор',
+      viewer: 'Наблюдатель',
+    },
+    actions: {
+      submit: 'Создать аккаунт',
+    },
+  },
+  settings: {
+    page: {
+      title: 'Настройки',
+      description: 'Обновите информацию профиля и параметры уведомлений.',
+    },
+    fields: {
+      namePlaceholder: 'Имя',
+      emailPlaceholder: 'Email',
+    },
+  },
+  blank: {
+    page: {
+      title: 'Пустая страница',
+      description: 'Начните с чистого листа.',
+      content: 'Настройте эту страницу, добавив компоненты или визуализацию данных.',
+    },
+  },
+  system: {
+    error: {
+      title: 'Что-то пошло не так',
+    },
+    notFound: {
+      title: '404 — Страница не найдена',
+      description: 'Страница, которую вы ищете, не существует.',
     },
   },
 }


### PR DESCRIPTION
## Summary
- replace hardcoded labels in dashboard sections, forms, settings, and blank pages with translations from useLocale
- internationalize shared UI components such as header, tables, empty states, and confirmation dialogs
- extend locale dictionaries with new helper keys for units, table messaging, and menu actions

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d3d3805aa4832ab611581d754dfcfb