### PR TITLE
docs: improve contributor guidance for new pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,10 +64,17 @@ styles/, tailwind.config.ts, eslint.config.mjs, jest.config.js
 
 ## Customize
 
-- **Branding & theme**: Update design tokens in `app/globals.css` and Tailwind config; see `docs/theming.md`.
-- **Navigation & layout**: Adjust shell components in `components/layout/*` (sidebar, header, breadcrumbs).
+- **Branding & theme**: Update design tokens in `app/globals.css` and Tailwind config; see [`docs/theming.md`](docs/theming.md).
+- **Navigation & layout**: Adjust shell components in `components/layout/*` (sidebar, header, breadcrumbs) and register new items via `constants/nav.ts`.
 - **Data & validation**: Modify schemas in `lib/validators`, swap SWR hooks for your data fetching layer, and update mocks under `mocks/data`.
-- **UI primitives**: Extend shadcn-style components in `components/ui` or generate new ones with the shadcn CLI.
+- **UI primitives**: Extend the React components in `components/ui` or scaffold new ones following the same API surface.
+
+## Guides
+
+- **Add a new page**: Follow the step-by-step checklist in [`docs/creating-pages.md`](docs/creating-pages.md).
+- **Component catalogue**: Browse props and usage notes in [`docs/components.md`](docs/components.md).
+- **Advanced forms**: Learn how `react-hook-form` and Zod fit together in [`docs/forms.md`](docs/forms.md).
+- **Theming**: Customize colors, typography, and spacing tokens using [`docs/theming.md`](docs/theming.md).
 
 ## Mock API
 

--- a/docs/components.md
+++ b/docs/components.md
@@ -1,333 +1,132 @@
-# Components API Documentation
+# Component Catalogue
 
-This document provides detailed API documentation for all components in the Admin Dashboard template.
+This guide explains how the reusable pieces of the dashboard fit together and which props they expect. Components are grouped by feature area so you can quickly discover what to import when assembling new pages.
 
-## Table of Contents
+## Directory Map
 
-1. [UI Components](#ui-components)
-2. [Layout Components](#layout-components)
-3. [Data Display Components](#data-display-components)
-4. [Form Components](#form-components)
-5. [Feedback Components](#feedback-components)
-6. [Chart Components](#chart-components)
+- [`components/layout`](../components/layout): shell primitives such as the sidebar, header, breadcrumbs, and page wrapper.
+- [`components/ui`](../components/ui): low-level inputs and buttons that expose native HTML props with Tailwind styling.
+- [`components/data-table`](../components/data-table): TanStack Table wrappers used on the Users screen.
+- [`components/forms`](../components/forms): form sections composed around `react-hook-form` registries.
+- [`components/dashboard`](../components/dashboard) and [`components/examples`](../components/examples): pre-built cards, charts, and composite blocks used for demos.
+- [`components/feedback`](../components/feedback): notification helpers (`ToasterProvider`) wired to Sonner.
 
-## UI Components
+## Layout primitives
 
-### Button
+### `PageLayout`
 
-A flexible button component with various styles and states.
+Location: [`components/layout/PageLayout.tsx`](../components/layout/PageLayout.tsx)
 
 ```tsx
-import { Button } from '@/components/ui/Button'
-
-// Basic usage
-<Button>Click me</Button>
-
-// With different variations
-<Button type="submit">Submit</Button>
-<Button disabled>Disabled</Button>
-<Button className="custom-class">Custom Style</Button>
+<PageLayout
+  title="Customers"
+  description="Monitor growth and engagement."
+  actions={<Button className="btn-primary">Export</Button>}
+>
+  <section className="section-container">{/* page content */}</section>
+</PageLayout>
 ```
 
-**Props:**
+Props:
 
-- `className?: string` - Additional CSS classes
-- `type?: 'button' | 'submit' | 'reset'` - HTML button type
-- `disabled?: boolean` - Disable button
-- `...rest` - All other button HTML attributes
+| Prop | Type | Description |
+| --- | --- | --- |
+| `title?` | `string` | Optional page heading rendered as `<h1>`. |
+| `description?` | `string` | Supporting text under the title. |
+| `actions?` | `ReactNode` | Slot aligned to the right of the header (buttons, filters, etc.). |
+| `breadcrumbs?` | `ReactNode \| null` | Custom breadcrumbs element. Pass `null` to hide. Defaults to `<Breadcrumbs />`. |
+| `className?` | `string` | Extra classes for the outer wrapper (`page-container`). |
+| `contentClassName?` | `string` | Classes applied to the content wrapper (`space-y-6` by default). |
 
-### Input
+### `Breadcrumbs`
 
-A styled input component with built-in support for forms.
+Location: [`components/layout/Breadcrumbs.tsx`](../components/layout/Breadcrumbs.tsx)
 
-```tsx
-import { Input } from '@/components/ui/Input'
+Automatically derives labels from the current pathname and links back to `/dashboard`. Translators can override the first crumb through `navigation.items.home` in the locale files.
 
-// Basic usage
-<Input placeholder="Enter text" />
+Props: `{ className?: string }` to append styling classes.
 
-// With form integration
-<Input
-  type="email"
-  placeholder="Email"
-  {...register('email')}
-/>
-```
+### `Sidebar`
 
-**Props:**
+Location: [`components/layout/Sidebar.tsx`](../components/layout/Sidebar.tsx)
 
-- `className?: string` - Additional CSS classes
-- `type?: string` - HTML input type
-- `...rest` - All other input HTML attributes
+Renders navigation sections defined in [`constants/nav.ts`](../constants/nav.ts). Items inherit styles from the `.nav-item` and `.nav-item-active` utility classes in [`app/globals.css`](../app/globals.css). The component automatically:
 
-### Select
+- Filters items by `roles` (a simple example currently hardcodes the `admin` role).
+- Highlights the active link based on the current pathname.
+- Closes itself on mobile once a link is selected.
+- Invokes `handleAction` for `type: "action"` entries (used by the mock logout button).
 
-A custom select component for dropdowns.
+### `Header`
 
-```tsx
-import { Select } from '@/components/ui/Select'
+Location: [`components/layout/Header.tsx`](../components/layout/Header.tsx)
 
-// Basic usage
-<Select>
-  <option value="1">Option 1</option>
-  <option value="2">Option 2</option>
-</Select>
+Displays the mobile sidebar toggle, localized product name, theme switcher, locale switcher, and account avatar menu. Hooks into `SidebarProvider` and `next-themes` so it requires both providers in the root layout (already configured in `app/layout.tsx`).
 
-// With form integration
-<Select {...register('role')}>
-  <option value="admin">Admin</option>
-  <option value="user">User</option>
-</Select>
-```
+## UI primitives
 
-**Props:**
+These components forward refs and native HTML attributes, making them drop-in replacements for standard elements with consistent styling.
 
-- `className?: string` - Additional CSS classes
-- `...rest` - All other select HTML attributes
+| Component | Location | Notes |
+| --- | --- | --- |
+| `Button` | [`components/ui/Button.tsx`](../components/ui/Button.tsx) | Primary CTA styling. Extend via the `className` prop or combine with `.btn-*` utilities from `app/globals.css`. |
+| `Input` | [`components/ui/Input.tsx`](../components/ui/Input.tsx) | Full-width text input with light/dark backgrounds. Works with `react-hook-form` because it forwards refs. |
+| `Select` | [`components/ui/Select.tsx`](../components/ui/Select.tsx) | Styled `<select>` element. Accepts all native props. |
+| `Checkbox` | [`components/ui/Checkbox.tsx`](../components/ui/Checkbox.tsx) | Uses the brand accent color and plays nicely with `register`. |
+| `Switch` | [`components/ui/Switch.tsx`](../components/ui/Switch.tsx) | Controlled toggle component with `checked`/`onCheckedChange` props. |
+| `Dialog` | [`components/ui/Dialog.tsx`](../components/ui/Dialog.tsx) | Simple modal portal. Provide `open`, `onClose`, and optional `title`. |
+| `DropdownMenu` | [`components/ui/DropdownMenu.tsx`](../components/ui/DropdownMenu.tsx) | Lightweight menu built on shadcn primitives for contextual actions. |
+| `Tabs` | [`components/ui/Tabs.tsx`](../components/ui/Tabs.tsx) | Horizontal tab switcher; supply `items` and `value/onValueChange`. |
+| `Toggle` | [`components/ui/Toggle.tsx`](../components/ui/Toggle.tsx) | Icon/text toggle button that exposes a pressed state. |
+| `Skeleton` | [`components/ui/Skeleton.tsx`](../components/ui/Skeleton.tsx) | Animated placeholder block for loading states. |
 
-### Checkbox
+Each file exports a single component—inspect the source if you need additional variants or to adapt them to a design system.
 
-A styled checkbox component.
+## Data table toolkit
 
-```tsx
-import { Checkbox } from '@/components/ui/Checkbox'
+The Users page relies on a small toolkit around TanStack Table located in [`components/data-table`](../components/data-table).
 
-// Basic usage
-<Checkbox />
+- **`DataTable`** wraps the entire experience: pagination, search, column visibility, and localized summary text. Configure it with `columns`, `data`, and optional `searchKey` / `searchKeys` for global filtering.
+- **`useConfiguredTable`** centralizes table state (sorting, filtering, pagination) and wires localization placeholders. Import it directly if you need custom rendering with the same behavior.
+- **`DataTableToolbar`** combines the search input and column visibility menu. Pass it a `table` instance, the current `filter` string, and the `onFilterChange` handler returned by `useConfiguredTable`.
+- **`DataTableBody`** renders the table element, header groups, empty state, and row cells.
+- **`Pagination`** renders the footer controls and page-size selector. `DataTable` injects localized labels from `useLocale()`.
 
-// With label
-<div className="flex items-center gap-2">
-  <Checkbox {...register('active')} />
-  <span>Active</span>
-</div>
-```
-
-**Props:**
-
-- `className?: string` - Additional CSS classes
-- `...rest` - All other checkbox HTML attributes
-
-### Dialog
-
-A modal dialog component.
+Example usage:
 
 ```tsx
-import { Dialog } from "@/components/ui/Dialog";
-
-// Basic usage
-<Dialog open={isOpen} onClose={() => setIsOpen(false)} title="Dialog Title">
-  <p>Dialog content</p>
-</Dialog>;
-```
-
-**Props:**
-
-- `open: boolean` - Control dialog visibility
-- `onClose: () => void` - Close handler
-- `title?: string` - Dialog title
-- `children: ReactNode` - Dialog content
-
-## Layout Components
-
-### Sidebar
-
-Main navigation sidebar component.
-
-```tsx
-import Sidebar from "@/components/layout/Sidebar";
-
-// Basic usage
-<Sidebar />;
-```
-
-The component uses the SidebarProvider context for state management.
-
-### Header
-
-Top header component with user menu and theme toggle.
-
-```tsx
-import Header from "@/components/layout/Header";
-
-// Basic usage
-<Header />;
-```
-
-### Breadcrumbs
-
-Navigation breadcrumbs component.
-
-```tsx
-import Breadcrumbs from "@/components/layout/Breadcrumbs";
-
-// Basic usage
-<Breadcrumbs
-  items={[
-    { label: "Home", href: "/" },
-    { label: "Users", href: "/users" },
-    { label: "Details" },
-  ]}
-/>;
-```
-
-**Props:**
-
-- `items: Array<{ label: string; href?: string }>` - Breadcrumb items
-
-## Data Display Components
-
-### DataTable
-
-A powerful table component built with TanStack Table.
-
-```tsx
-import DataTable from '@/components/data-table/DataTable'
-import type { ColumnDef } from '@tanstack/react-table'
-
-// Define columns
 const columns: ColumnDef<User>[] = [
-  { header: 'Name', accessorKey: 'name' },
-  { header: 'Email', accessorKey: 'email' },
-]
+  { accessorKey: "name", header: t("users.table.columns.name") },
+  { accessorKey: "email", header: t("users.table.columns.email") },
+];
 
-// Basic usage
 <DataTable
   columns={columns}
   data={users}
+  searchKeys={["name", "email"]}
+  initialPageSize={10}
 />
 ```
 
-**Props:**
+## Form sections
 
-- `columns: ColumnDef[]` - Table column definitions
-- `data: any[]` - Table data
-- `pageSize?: number` - Items per page (default: 10)
+Form-heavy screens compose small sections that expect `react-hook-form` registries. Each component accepts typed props to avoid prop drilling mistakes:
 
-### Pagination
+- [`BasicInfoSection`](../components/forms/BasicInfoSection.tsx) – text inputs, password strength meter, and helper text for errors.
+- [`RoleStatusSection`](../components/forms/RoleStatusSection.tsx) – role select, status toggle, and active checkbox.
+- [`SkillsSelector`](../components/forms/SkillsSelector.tsx) – multi-select with badge list driven by the `useSkillsFieldArray` hook.
+- [`AddressSection`](../components/forms/AddressSection.tsx) – grouped address fields with state dropdown.
+- [`NotificationsSection`](../components/forms/NotificationsSection.tsx) – switch controls for notification channels.
+- [`AgreementSection`](../components/forms/AgreementSection.tsx) – checkbox consent and submit button slot.
 
-Table pagination component.
+Refer to [`app/forms/page.tsx`](../app/forms/page.tsx) for a complete example of how these sections collaborate with hooks in `lib/hooks` and constants from `constants/forms`.
 
-```tsx
-import Pagination from "@/components/data-table/Pagination";
+## Feedback helpers
 
-// Basic usage
-<Pagination
-  currentPage={1}
-  totalPages={5}
-  onPageChange={(page) => setPage(page)}
-/>;
-```
+- [`components/feedback/ToasterProvider.tsx`](../components/feedback/ToasterProvider.tsx) wraps the Sonner `<Toaster />` component with sensible defaults (position, rich colors). Include it once in `app/layout.tsx` to enable toast notifications project-wide.
 
-**Props:**
+## Example gallery
 
-- `currentPage: number` - Current page number
-- `totalPages: number` - Total number of pages
-- `onPageChange: (page: number) => void` - Page change handler
+The [`app/examples`](../app/examples) directory doubles as a living style guide: charts, cards, timelines, and form fragments. When designing a new screen, copy sections from here into your page and plug in real data or locale-aware text.
 
-## Chart Components
-
-### LineChart
-
-Line chart component using Chart.js.
-
-```tsx
-import LineChart from "@/components/charts/LineChart";
-
-// Basic usage
-<LineChart
-  data={[
-    { date: "2024-01", value: 100 },
-    { date: "2024-02", value: 150 },
-  ]}
-/>;
-```
-
-**Props:**
-
-- `data: Array<{ date: string; value: number }>` - Chart data points
-
-### BarChart
-
-Bar chart component using Chart.js.
-
-```tsx
-import BarChart from "@/components/charts/BarChart";
-
-// Basic usage
-<BarChart
-  data={[
-    { label: "Category 1", value: 100 },
-    { label: "Category 2", value: 150 },
-  ]}
-  label="Sales"
-/>;
-```
-
-**Props:**
-
-- `data: Array<{ label: string; value: number }>` - Chart data
-- `label?: string` - Chart label
-
-### DoughnutChart
-
-Doughnut chart component using Chart.js.
-
-```tsx
-import DoughnutChart from "@/components/charts/DoughnutChart";
-
-// Basic usage
-<DoughnutChart
-  data={[
-    { label: "Type A", value: 30 },
-    { label: "Type B", value: 70 },
-  ]}
-/>;
-```
-
-**Props:**
-
-- `data: Array<{ label: string; value: number }>` - Chart data
-- `label?: string` - Chart label
-
-## Feedback Components
-
-### ToasterProvider
-
-Toast notification provider using Sonner.
-
-```tsx
-import ToasterProvider from "@/components/feedback/ToasterProvider";
-import { toast } from "sonner";
-
-// Setup in layout
-<ToasterProvider />;
-
-// Usage
-toast.success("Operation successful");
-toast.error("Something went wrong");
-```
-
-### ConfirmModal
-
-Confirmation dialog component.
-
-```tsx
-import ConfirmModal from "@/components/common/ConfirmModal";
-
-// Basic usage
-<ConfirmModal
-  open={isOpen}
-  title="Delete Item"
-  description="Are you sure you want to delete this item?"
-  onConfirm={handleDelete}
-  onCancel={() => setIsOpen(false)}
-/>;
-```
-
-**Props:**
-
-- `open: boolean` - Control modal visibility
-- `title: string` - Modal title
-- `description?: string` - Modal description
-- `onConfirm: () => void` - Confirm action handler
-- `onCancel: () => void` - Cancel action handler
+Use this catalogue in conjunction with the [new page checklist](creating-pages.md) to build consistent screens quickly.

--- a/docs/creating-pages.md
+++ b/docs/creating-pages.md
@@ -1,0 +1,106 @@
+# Creating a New Page
+
+Use this checklist whenever you add a route inside the admin dashboard. It mirrors the manual steps already used across the repository so you can stay consistent without scaffolding scripts.
+
+## Quick Checklist
+
+1. Duplicate `app/blank/page.tsx` into `app/<your-route>/page.tsx` and adjust the slug.
+2. Replace the placeholder copy in the new file while keeping the `PageLayout` wrapper.
+3. Add a navigation item in `constants/nav.ts` for the new page.
+4. Provide translations for the navigation label and page copy in every file under `locales/`.
+5. Drop in UI blocks from `components/` or the examples under `app/examples/`.
+6. Connect data through hooks in `lib/hooks/` or by creating route handlers under `app/api/`.
+7. Verify the page renders, navigation is updated, and localization works in each language.
+
+## 1. Create the route file
+
+Routes in the App Router map to folders under `app/`. Create a new directory and copy the blank template to inherit the standard layout:
+
+```bash
+cp app/blank/page.tsx app/reports/page.tsx
+```
+
+Open the new file and tweak the metadata and content. Keep the `PageLayout` wrapper so you get breadcrumbs, responsive spacing, and the actions slot for free:
+
+```tsx
+"use client";
+import PageLayout from "@/components/layout/PageLayout";
+import { useLocale } from "@/contexts/LocaleProvider";
+
+export default function ReportsPage() {
+  const { t } = useLocale();
+  return (
+    <PageLayout
+      title={t("reports.page.title", "Reports")}
+      description={t(
+        "reports.page.description",
+        "Review performance metrics and export summaries.",
+      )}
+    >
+      <section className="section-container">
+        {/* Replace this block with your layout or components */}
+      </section>
+    </PageLayout>
+  );
+}
+```
+
+## 2. Register the page in the sidebar
+
+Navigation is fully driven by `NAV_SECTIONS` in [`constants/nav.ts`](../constants/nav.ts). Append a new item under the `main` section so the sidebar and breadcrumbs pick it up:
+
+```ts
+{
+  key: "reports",
+  titleKey: "navigation.items.reports",
+  href: "/reports",
+  icon: FileText,
+},
+```
+
+Keep the `key` unique and align it with the slug. Icons come from `lucide-react`; see the existing imports at the top of the file for inspiration.
+
+## 3. Add translation strings
+
+Every locale file under [`locales/`](../locales) exports a flat object. Define your navigation label under `navigation.items` and the page copy under a namespaced key that matches your page:
+
+```ts
+// locales/en.ts
+reports: {
+  page: {
+    title: "Reports",
+    description: "Review performance metrics and export summaries.",
+    empty: "No reports generated yet.",
+  },
+},
+```
+
+Repeat the same structure in `locales/es.ts`, `locales/fr.ts`, and `locales/ru.ts`. Leaving fallback strings inside `t()` calls is fine during development, but committed code should include localized values.
+
+## 4. Assemble the layout
+
+Re-use the building blocks that are already styled:
+
+- `section-container`, `grid-container`, and heading utility classes are defined in [`app/globals.css`](../app/globals.css).
+- High-level layout primitives live under [`components/layout`](../components/layout) (breadcrumbs, page headers, sidebar shell).
+- Common UI widgets (`Button`, `Input`, `Select`, `Dialog`, etc.) are available in [`components/ui`](../components/ui).
+- Reference-ready compositions (charts, cards, forms) are showcased under [`app/examples`](../app/examples); copy the JSX you need and wire it with your data.
+
+## 5. Hook up data (optional)
+
+For asynchronous data, start with the shared utilities:
+
+- [`lib/hooks/useData`](../lib/hooks/useData.ts) wraps SWR and returns `{ data, isLoading, isError, isEmpty, mutate }` for consistent loading states.
+- [`app/api`](../app/api) contains route handlers powered by the JSON fixtures in [`mocks/data`](../mocks/data). Clone an existing handler if you need quick mock endpoints.
+- [`lib/validators.ts`](../lib/validators.ts) provides Zod schemas you can extend to keep forms and APIs in sync.
+
+## 6. Smoke-test the page
+
+Run through this short QA loop before committing:
+
+- Load the page in the browser and confirm breadcrumbs show the new label.
+- Toggle the language from the header to ensure localized strings resolve.
+- Check the responsive layout at narrow and wide breakpoints.
+- Run `npm run lint` and `npm run test` if you touched shared components or logic.
+
+Keeping these steps in sync with the rest of the documentation ensures the project stays approachable even without a dedicated scaffolding CLI.

--- a/docs/forms.md
+++ b/docs/forms.md
@@ -1,274 +1,86 @@
-# Forms and Validation Guide
+# Forms & Validation
 
-This guide explains how to work with forms and validation in the Admin Dashboard template.
+The Forms demo (`/forms`) showcases how the project wires `react-hook-form`, Zod schemas, and reusable sections together. This guide captures the patterns so you can adapt them to new screens.
 
-## Table of Contents
+## Stack overview
 
-1. [Form Setup](#form-setup)
-2. [Validation Schemas](#validation-schemas)
-3. [Complex Form Examples](#complex-form-examples)
-4. [Custom Components](#custom-components)
+- **Form state**: [`useForm`](https://react-hook-form.com/) from `react-hook-form` with the `zodResolver` helper.
+- **Schemas & types**: [`userSchema` and helpers](../lib/validators.ts).
+- **UI sections**: Components under [`components/forms`](../components/forms) render grouped fields and expect `register`, `errors`, and helper callbacks.
+- **Feedback**: Sonner toasts via [`components/feedback/ToasterProvider`](../components/feedback/ToasterProvider.tsx).
+- **Async helpers**: Hooks in [`lib/hooks`](../lib/hooks) add UX sugar such as password strength meters and field arrays.
 
-## Form Setup
+## Bootstrapping a form
 
-The template uses React Hook Form with Zod for form handling and validation.
-
-### Basic Form Setup
-
-```tsx
-import { useForm } from "react-hook-form";
-import { zodResolver } from "@hookform/resolvers/zod";
-import { userSchema, UserFormValues } from "@/lib/validators";
-
-function MyForm() {
-  const {
-    register,
-    handleSubmit,
-    formState: { errors },
-  } = useForm<UserFormValues>({
-    resolver: zodResolver(userSchema),
-    defaultValues: {
-      // Your default values
-    },
-  });
-
-  const onSubmit = (data: UserFormValues) => {
-    // Handle form submission
-  };
-
-  return <form onSubmit={handleSubmit(onSubmit)}>{/* Form fields */}</form>;
-}
-```
-
-### Field Registration
+The default page is implemented in [`app/forms/page.tsx`](../app/forms/page.tsx). The snippet below highlights the recommended structure:
 
 ```tsx
-// Text input
-<Input {...register('name')} />
-
-// Select
-<Select {...register('role')}>
-  <option value="admin">Admin</option>
-  <option value="user">User</option>
-</Select>
-
-// Checkbox
-<Checkbox {...register('active')} />
-```
-
-### Error Handling
-
-```tsx
-<div>
-  <Input {...register("email")} />
-  {errors.email && (
-    <p className="text-sm text-red-600">{errors.email.message}</p>
-  )}
-</div>
-```
-
-## Validation Schemas
-
-The template uses Zod for type-safe form validation.
-
-### Basic Schema Example
-
-```typescript
-import { z } from "zod";
-
-export const userSchema = z.object({
-  name: z.string().min(2, "Name must be at least 2 characters"),
-  email: z.string().email("Invalid email address"),
-  role: z.enum(["admin", "editor", "viewer"]),
-  active: z.boolean(),
+const form = useForm<UserFormValues>({
+  resolver: zodResolver(userSchema),
+  defaultValues: {
+    active: true,
+    role: "viewer",
+    notifications: { email: true, sms: false, push: true },
+    skills: [],
+    address: { country: "United States" },
+  },
 });
 
-export type UserFormValues = z.infer<typeof userSchema>;
+const {
+  register,
+  control,
+  handleSubmit,
+  formState: { errors },
+} = form;
 ```
 
-### Advanced Validation Examples
+- `UserFormValues` is inferred from the Zod schema, keeping types in sync.
+- `defaultValues` mirror the shape of the schema. Reuse them when building optimistic UI for your APIs.
 
-```typescript
-// Password validation with regex
-const passwordSchema = z
-  .string()
-  .regex(
-    /^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[@$!%*?&])[A-Za-z\d@$!%*?&]{8,}$/,
-    "Password must contain at least 8 characters, one uppercase letter, one lowercase letter, one number and one special character",
-  );
+## Section components
 
-// Date validation
-const dateSchema = z.string().refine((date) => {
-  const age =
-    (new Date().getTime() - new Date(date).getTime()) /
-    (1000 * 60 * 60 * 24 * 365.25);
-  return age >= 18;
-}, "Must be at least 18 years old");
+Each section encapsulates markup and validation hints. Pass only the pieces it needs:
 
-// Phone number validation
-const phoneSchema = z
-  .string()
-  .regex(/^\+?[1-9]\d{1,14}$/, "Invalid phone number format")
-  .optional()
-  .nullable();
-```
+| Component | Purpose | Required props |
+| --- | --- | --- |
+| `BasicInfoSection` | Name, email, password, phone | `register`, `errors`, `passwordStrength`, `onPasswordChange` |
+| `RoleStatusSection` | Role select & status toggles | `register`, `errors` |
+| `SkillsSelector` | Dynamic skills list with chips | `register`, `errors`, `skills`, `isSkillSelected` |
+| `AddressSection` | Address fields and state dropdown | `register`, `errors`, `states` |
+| `NotificationsSection` | Notification switches | `register` |
+| `AgreementSection` | Terms checkbox + submit CTA | `register`, `errors` |
 
-### Nested Object Validation
+`errors` comes from `formState.errors` and is typed via `UserFormValues`, so TypeScript will complain if you ask for an unknown key.
 
-```typescript
-const addressSchema = z.object({
-  street: z.string().min(5, "Street address must be at least 5 characters"),
-  city: z.string().min(2, "City name must be at least 2 characters"),
-  state: z.string().length(2, "Please use 2-letter state code"),
-  zipCode: z.string().regex(/^\d{5}(-\d{4})?$/, "Invalid ZIP code format"),
-});
+## Custom hooks
 
-const userSchema = z.object({
-  // ... other fields
-  address: addressSchema,
-});
-```
+Two hooks in [`lib/hooks`](../lib/hooks) support the example form but can be reused elsewhere:
 
-## Complex Form Examples
+- [`usePasswordStrength`](../lib/hooks/usePasswordStrength.ts) returns `{ strength, handlePasswordChange }`. Call `handlePasswordChange` inside the password field’s `onChange` handler to keep the meter in sync.
+- [`useSkillsFieldArray`](../lib/hooks/useSkillsFieldArray.ts) wraps `useFieldArray` and exposes `fields`, `append`, `remove`, and a convenience `isSkillSelected` checker used by the chip list.
 
-### Form with Dynamic Fields
+## Validation & localization
 
-```tsx
-function DynamicForm() {
-  const { control, register } = useForm();
-  const { fields, append, remove } = useFieldArray({
-    control,
-    name: "skills",
-  });
+- All validation messages are defined in the schema (`lib/validators.ts`). Adjust them there so translations stay centralized.
+- Display errors below fields using the `errors` map. Each section already renders the hint placeholder so you only need to pass `errors` down.
+- Surface submit feedback with Sonner: `toast.success(t("common.messages.formSubmitted"))`. The locale keys live under `common.messages`.
 
-  return (
-    <form>
-      {fields.map((field, index) => (
-        <div key={field.id}>
-          <Input {...register(`skills.${index}`)} />
-          <Button onClick={() => remove(index)}>Remove</Button>
-        </div>
-      ))}
-      <Button onClick={() => append("")}>Add Skill</Button>
-    </form>
-  );
-}
-```
+## Submission patterns
 
-### Form with File Upload
+Inside `handleSubmit`, either:
 
-```tsx
-function FileUploadForm() {
-  const { register, watch } = useForm();
-  const file = watch("avatar");
+1. Post to an API route (see [`app/api/users/route.ts`](../app/api/users/route.ts)) and await the response.
+2. Fire a toast and mutate cached data via `useData().mutate` for optimistic updates.
 
-  return (
-    <form>
-      <input type="file" accept="image/*" {...register("avatar")} />
-      {file && file[0] && (
-        <img
-          src={URL.createObjectURL(file[0])}
-          alt="Preview"
-          className="h-20 w-20 rounded-full"
-        />
-      )}
-    </form>
-  );
-}
-```
+Wrap async calls in `try/catch` and surface errors using the localized strings under `common.errors` or `common.messages`.
 
-### Multi-step Form
+## Reusing the layout
 
-```tsx
-function MultiStepForm() {
-  const [step, setStep] = useState(1);
-  const { register, handleSubmit } = useForm();
+To drop this form into another page:
 
-  const onSubmit = (data: any) => {
-    if (step < 3) {
-      setStep(step + 1);
-    } else {
-      // Submit form
-    }
-  };
+1. Import the section components you need.
+2. Reuse the same schema or compose a new one in [`lib/validators.ts`](../lib/validators.ts).
+3. Keep the surrounding layout consistent with `<PageLayout>` and `.section-container` wrappers.
+4. Update the translation keys under `forms.*` to reflect your wording.
 
-  return (
-    <form onSubmit={handleSubmit(onSubmit)}>
-      {step === 1 && (
-        <div>
-          <h2>Basic Information</h2>
-          <Input {...register("name")} />
-          <Input {...register("email")} />
-        </div>
-      )}
-
-      {step === 2 && (
-        <div>
-          <h2>Address</h2>
-          <Input {...register("address.street")} />
-          <Input {...register("address.city")} />
-        </div>
-      )}
-
-      {step === 3 && (
-        <div>
-          <h2>Preferences</h2>
-          <Checkbox {...register("notifications")} />
-        </div>
-      )}
-
-      <Button type="submit">{step < 3 ? "Next" : "Submit"}</Button>
-    </form>
-  );
-}
-```
-
-## Custom Components
-
-### Password Strength Meter
-
-```tsx
-type Props = {
-  strength: number; // 0-5
-};
-
-export default function PasswordStrengthMeter({ strength }: Props) {
-  const getColor = (value: number) => {
-    if (value <= 2) return "bg-red-500";
-    if (value <= 3) return "bg-yellow-500";
-    if (value <= 4) return "bg-blue-500";
-    return "bg-green-500";
-  };
-
-  return (
-    <div className="mt-1">
-      <div className="flex h-1.5 w-full overflow-hidden rounded bg-gray-200">
-        {[...Array(5)].map((_, i) => (
-          <div
-            key={i}
-            className={`h-full w-1/5 ${i < strength ? getColor(strength) : ""}`}
-          />
-        ))}
-      </div>
-    </div>
-  );
-}
-```
-
-### Form Section Card
-
-```tsx
-type Props = {
-  title: string;
-  children: React.ReactNode;
-};
-
-export default function FormSection({ title, children }: Props) {
-  return (
-    <div className="rounded-lg bg-white p-6 shadow dark:bg-gray-800">
-      <h2 className="mb-4 text-lg font-semibold">{title}</h2>
-      {children}
-    </div>
-  );
-}
-```
+Following this pattern keeps forms consistent across the dashboard and makes it easy to share validation logic between server handlers and client components.

--- a/docs/theming.md
+++ b/docs/theming.md
@@ -1,240 +1,79 @@
-# Theming and Customization Guide
+# Theming & Styling
 
-This guide explains how to customize the look and feel of the Admin Dashboard template.
+The dashboard ships with opinionated design tokens and utility classes so that new pages look consistent out of the box. This document shows where those tokens live and how to extend them safely.
 
-## Table of Contents
+## Color tokens
 
-1. [Theme Setup](#theme-setup)
-2. [Color Customization](#color-customization)
-3. [Component Styling](#component-styling)
-4. [Dark Mode](#dark-mode)
-5. [Layout Customization](#layout-customization)
-
-## Theme Setup
-
-The template uses Tailwind CSS for styling and next-themes for dark mode support.
-
-### Base Configuration
-
-```js
-// tailwind.config.js
-module.exports = {
-  content: [
-    "./pages/**/*.{js,ts,jsx,tsx,mdx}",
-    "./components/**/*.{js,ts,jsx,tsx,mdx}",
-    "./app/**/*.{js,ts,jsx,tsx,mdx}",
-  ],
-  darkMode: "class",
-  theme: {
-    extend: {
-      colors: {
-        // Your custom colors
-      },
-    },
-  },
-  plugins: [],
-};
-```
-
-### Theme Provider Setup
-
-```tsx
-// contexts/ThemeProvider.tsx
-"use client";
-import { ThemeProvider as NextThemesProvider } from "next-themes";
-import type { ReactNode } from "react";
-
-export function ThemeProvider({ children }: { children: ReactNode }) {
-  return (
-    <NextThemesProvider attribute="class" defaultTheme="system" enableSystem>
-      {children}
-    </NextThemesProvider>
-  );
-}
-```
-
-## Color Customization
-
-### Custom Colors
+All brand colors are defined as CSS custom properties inside [`app/globals.css`](../app/globals.css). Update them to change the look of the entire app:
 
 ```css
-/* app/globals.css */
-@layer base {
-  :root {
-    --background: 0 0% 100%;
-    --foreground: 240 10% 3.9%;
-    --primary: 240 5.9% 10%;
-    --primary-foreground: 0 0% 98%;
-    --secondary: 240 4.8% 95.9%;
-    --secondary-foreground: 240 5.9% 10%;
-    /* Add your custom colors here */
-  }
+:root {
+  --primary: 240 5.9% 10%;
+  --primary-foreground: 0 0% 98%;
+  --accent: 240 4.8% 95.9%;
+  --background: 0 0% 100%;
+  --foreground: 240 10% 3.9%;
+  --radius: 0.5rem;
+}
 
-  .dark {
-    --background: 240 10% 3.9%;
-    --foreground: 0 0% 98%;
-    /* Dark mode colors */
-  }
+.dark {
+  --primary: 0 0% 98%;
+  --primary-foreground: 240 5.9% 10%;
+  --background: 240 10% 3.9%;
+  --foreground: 0 0% 98%;
 }
 ```
 
-### Using Custom Colors
+Use [HSL values](https://developer.mozilla.org/en-US/docs/Web/CSS/color_value/hsl) so the Tailwind theme extension can reference them via `hsl(var(--token))`. Remember to touch both the light and dark sections when adjusting brand colors.
+
+## Tailwind configuration
+
+[`tailwind.config.ts`](../tailwind.config.ts) consumes the CSS variables above and extends spacing, typography, and animations:
+
+- `content` includes `app`, `components`, `contexts`, and `lib` directories, so your classes compile no matter where JSX lives.
+- `theme.extend.colors` maps semantic names (`primary`, `accent`, `card`, `success`, etc.) to the CSS tokens.
+- `theme.extend.spacing` defines `spacing.header` and `spacing.sidebar` used inside layout components.
+- `plugins` includes `@tailwindcss/forms` and `tailwindcss-animate` for better defaults.
+
+To add a new semantic color or spacing token, extend the relevant object and reference the same `var(--token)` in `globals.css`.
+
+## Utility classes
+
+`app/globals.css` registers a set of component-level classes inside `@layer components` to avoid repeating Tailwind utilities:
+
+- `.page-container` – consistent max-width and padding for every page.
+- `.section-container` – card-like wrapper used around content sections.
+- `.grid-container` – responsive gap defaults for dashboards.
+- `.heading-*` – typography presets for headings.
+- `.btn-*` – button variants (primary, secondary, outline, ghost, destructive, link).
+- `.nav-item` / `.nav-item-active` – sidebar list styling.
+- `.alert-*` – quick status banners (success, error, warning, info).
+
+Use these classes in your pages instead of duplicating Tailwind strings. If you need a new variant, add it under the same layer so PurgeCSS picks it up automatically.
+
+## Dark mode & toggles
+
+Dark mode is powered by [`next-themes`](https://github.com/pacocoursey/next-themes). The provider is set up in `app/layout.tsx` via `ThemeProvider`, and the header toggles it with:
 
 ```tsx
-// In components
-<div className="bg-background text-foreground">
-  <button className="bg-primary text-primary-foreground">Click me</button>
-</div>
+const { theme, setTheme } = useTheme();
+setTheme(theme === "dark" ? "light" : "dark");
 ```
 
-## Component Styling
+Because all CSS variables have `.dark` overrides, components instantly adopt the new palette. When introducing brand colors, supply both light and dark values to avoid low-contrast states.
 
-### Base Component Styles
+## Component-specific styling
 
-```tsx
-// components/ui/Button.tsx
-export function Button({
-  className = "",
-  ...props
-}: ButtonHTMLAttributes<HTMLButtonElement>) {
-  return (
-    <button
-      className={`inline-flex items-center justify-center rounded
-        bg-primary px-4 py-2 text-primary-foreground
-        hover:bg-primary/90 disabled:opacity-50 ${className}`}
-      {...props}
-    />
-  );
-}
-```
+- Layout components (`Sidebar`, `Header`, `PageLayout`) rely heavily on the utility classes above. Update `globals.css` if you need to tweak spacing globally.
+- UI primitives in [`components/ui`](../components/ui) accept `className` overrides, so you can opt-in to a different variant on a per-use basis.
+- Charts and cards inside [`components/dashboard`](../components/dashboard) use Tailwind utilities inline. Update them directly or extract a shared class into `globals.css`.
 
-### Extending Component Styles
+## Working with external themes
 
-```tsx
-// Custom button usage
-<Button className="bg-blue-600 hover:bg-blue-700">Custom Button</Button>
-```
+If you plan to load dynamic themes (e.g., from a design system or CMS):
 
-### Component Variants
+1. Keep the CSS variable names stable and update only their values at runtime.
+2. Consider exposing a `theme.json` file that exports an object of tokens which you merge into `:root` via inline styles.
+3. Run `npm run lint` after large theme changes to catch unused class names or typos.
 
-```tsx
-// Define variants
-type ButtonVariant = "default" | "outline" | "ghost";
-
-const buttonVariants: Record<ButtonVariant, string> = {
-  default: "bg-primary text-primary-foreground hover:bg-primary/90",
-  outline: "border border-primary text-primary hover:bg-primary/10",
-  ghost: "text-primary hover:bg-primary/10",
-};
-
-// Use in component
-export function Button({
-  variant = "default",
-  className = "",
-  ...props
-}: ButtonProps) {
-  return (
-    <button
-      className={`inline-flex items-center justify-center rounded px-4 py-2
-        disabled:opacity-50 ${buttonVariants[variant]} ${className}`}
-      {...props}
-    />
-  );
-}
-```
-
-## Dark Mode
-
-### Dark Mode Toggle
-
-```tsx
-"use client";
-import { useTheme } from "next-themes";
-
-export function ThemeToggle() {
-  const { theme, setTheme } = useTheme();
-
-  return (
-    <button
-      onClick={() => setTheme(theme === "dark" ? "light" : "dark")}
-      className="rounded-full p-2 hover:bg-gray-100 dark:hover:bg-gray-800"
-    >
-      {theme === "dark" ? "Light Mode" : "Dark Mode"}
-    </button>
-  );
-}
-```
-
-### Dark Mode Styles
-
-```tsx
-// Using dark mode variants
-<div className="bg-white text-gray-900 dark:bg-gray-800 dark:text-white">
-  <p className="text-gray-600 dark:text-gray-300">
-    This text adapts to dark mode
-  </p>
-</div>
-```
-
-## Layout Customization
-
-### Sidebar Customization
-
-```tsx
-// contexts/SidebarProvider.tsx
-export function SidebarProvider({ children }: { children: ReactNode }) {
-  const [isOpen, setIsOpen] = useState(true);
-  const [isMobile, setIsMobile] = useState(false);
-
-  // Add your custom logic here
-
-  return (
-    <SidebarContext.Provider value={{ isOpen, setIsOpen, isMobile }}>
-      {children}
-    </SidebarContext.Provider>
-  );
-}
-```
-
-### Custom Layout Wrapper
-
-```tsx
-export function DashboardLayout({ children }: { children: ReactNode }) {
-  return (
-    <div className="flex min-h-screen">
-      <Sidebar />
-      <div className="flex flex-1 flex-col">
-        <Header />
-        <main className="flex-1 p-4">{children}</main>
-      </div>
-    </div>
-  );
-}
-```
-
-### Responsive Design
-
-```tsx
-// Breakpoint customization
-<div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
-  {/* Grid items */}
-</div>
-
-// Mobile-first approach
-<div className="flex flex-col md:flex-row">
-  <div className="w-full md:w-1/4">Sidebar</div>
-  <div className="w-full md:w-3/4">Content</div>
-</div>
-```
-
-### Custom Container
-
-```tsx
-export function Container({ className = "", children }: ContainerProps) {
-  return (
-    <div className={`mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 ${className}`}>
-      {children}
-    </div>
-  );
-}
-```
+With these touchpoints you can rebrand the dashboard quickly without digging through every component.


### PR DESCRIPTION
## Summary
- add a comprehensive checklist for manually creating new pages
- refresh the component, forms, and theming docs to match the current codebase
- surface the documentation hub from the README for easier discovery

## Testing
- not run (documentation-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68d41df8df10832abb40d36e669c35e6