### PR TITLE
feat: configure fetcher base url and msw bypass

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ styles/, tailwind.config.ts, eslint.config.mjs, jest.config.js
 3. **Run** (`~1 min`): `npm run dev` and open `http://localhost:3000`
 4. **Optional**: `npm run test` for unit tests, `npm run lint` to enforce coding standards.
 
-> Tip: No environment variables are required for local demo. Set `NEXT_PUBLIC_API_MOCKING=disabled` to bypass MSW when you connect a real API.
+> Tip: No environment variables are required for local demo. Set `NEXT_PUBLIC_API_BASE_URL="https://your-api.example.com"` to target a remote service and `NEXT_PUBLIC_API_MOCKING=disabled` if you want to opt out of MSW entirely.
 
 ## Customize
 
@@ -79,12 +79,12 @@ styles/, tailwind.config.ts, eslint.config.mjs, jest.config.js
 ## Mock API
 
 - Development requests hit Next.js route handlers under `app/api` backed by JSON fixtures in `mocks/data`.
-- MSW browser worker (`mocks/browser.ts`) mirrors the same handlers for component testing and story demos.
+- MSW browser worker (`mocks/browser.ts`) mirrors the same handlers for component testing and story demos and automatically skips registration when `NEXT_PUBLIC_API_BASE_URL` points to anything other than the default `/api` path (including absolute URLs).
 - Toggle behavior with `NEXT_PUBLIC_API_MOCKING` or by removing `<MockServiceWorker />` from the app shell when deploying with real services.
 
 ## FAQ
 
-**How do I connect to a real backend?** Replace the fetchers in `lib/hooks/useData` with your client and point route handlers to your API or remove them entirely.
+**How do I connect to a real backend?** Set `NEXT_PUBLIC_API_BASE_URL` to your server (for example `https://api.example.com/v1`) so the shared fetcher resolves requests against it. You can keep the MSW mocks disabled automatically via that setting or remove the route handlers entirely when you're ready.
 
 **Can I deploy this to Vercel or another host?** Yes—run `npm run build` then deploy. The project uses standard Next.js build output.
 

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -20,14 +20,14 @@ export default function DashboardPage() {
     isLoading: isLoadingStats,
     isError: isStatsError,
     mutate: mutateStats,
-  } = useData<DashboardStats>("/api/stats");
+  } = useData<DashboardStats>("stats");
 
   const {
     data: users,
     isLoading: isLoadingUsers,
     isError: isUsersError,
     mutate: mutateUsers,
-  } = useData<User[]>("/api/users");
+  } = useData<User[]>("users");
 
   if (isLoadingStats || isLoadingUsers) {
     return <DashboardSkeleton />;

--- a/app/users/page.tsx
+++ b/app/users/page.tsx
@@ -13,10 +13,7 @@ import { TableSkeleton } from "@/components/loading/Skeletons";
 import { useLocale } from "@/contexts/LocaleProvider";
 
 export default function UsersPage() {
-  const { data, mutate, isLoading, error } = useSWR<User[]>(
-    "/api/users",
-    fetcher,
-  );
+  const { data, mutate, isLoading, error } = useSWR<User[]>("users", fetcher);
   const [deleteId, setDeleteId] = useState<string | null>(null);
   const { t } = useLocale();
 

--- a/lib/__tests__/fetcher.test.ts
+++ b/lib/__tests__/fetcher.test.ts
@@ -3,6 +3,7 @@ import { FetchError, fetcher } from "../fetcher";
 describe("fetcher", () => {
   afterEach(() => {
     jest.restoreAllMocks();
+    delete process.env.NEXT_PUBLIC_API_BASE_URL;
   });
 
   it("returns json for successful responses", async () => {
@@ -12,7 +13,13 @@ describe("fetcher", () => {
       json: () => Promise.resolve(data),
     } as any);
 
-    const result = await fetcher<typeof data>("/api");
+    const result = await fetcher<typeof data>("stats");
+    expect(global.fetch).toHaveBeenCalledWith(
+      "/api/stats",
+      expect.objectContaining({
+        credentials: "include",
+      }),
+    );
     expect(result).toEqual(data);
   });
 
@@ -23,7 +30,7 @@ describe("fetcher", () => {
       statusText: "Internal Server Error",
     } as any);
 
-    await expect(fetcher("/api")).rejects.toThrow(
+    await expect(fetcher("stats")).rejects.toThrow(
       "Failed to fetch data: 500 Internal Server Error",
     );
   });
@@ -38,7 +45,7 @@ describe("fetcher", () => {
     expect.assertions(4);
 
     try {
-      await fetcher("/api");
+      await fetcher("stats");
     } catch (error) {
       expect(error).toBeInstanceOf(FetchError);
       expect((error as FetchError).status).toBe(400);
@@ -48,5 +55,69 @@ describe("fetcher", () => {
       );
       expect((error as FetchError).name).toBe("FetchError");
     }
+  });
+
+  it("resolves requests against the configured api base url", async () => {
+    process.env.NEXT_PUBLIC_API_BASE_URL = "https://example.com/api";
+    const data = { ok: true };
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(data),
+    } as any);
+
+    await fetcher("users");
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      "https://example.com/api/users",
+      expect.any(Object),
+    );
+  });
+
+  it("merges default request init options", async () => {
+    const data = { ok: true };
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(data),
+    } as any);
+
+    await fetcher("stats", {
+      headers: {
+        Accept: "text/plain",
+      },
+    });
+
+    const [, init] = (global.fetch as jest.Mock).mock.calls[0];
+    const headers = init?.headers as Headers;
+
+    expect(init).toMatchObject({
+      credentials: "include",
+    });
+    expect(headers).toBeInstanceOf(Headers);
+    expect(headers.get("Accept")).toBe("text/plain");
+    expect(headers.get("Content-Type")).toBe("application/json");
+  });
+
+  it("preserves request objects", async () => {
+    const data = { ok: true };
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(data),
+    } as any);
+
+    const request = {
+      url: "https://example.com/test",
+      headers: {
+        Authorization: "Bearer token",
+      },
+    } as Request;
+
+    await fetcher(request);
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      request,
+      expect.objectContaining({
+        credentials: "include",
+      }),
+    );
   });
 });

--- a/lib/fetcher.ts
+++ b/lib/fetcher.ts
@@ -1,3 +1,95 @@
+export const DEFAULT_API_BASE_URL = "/api";
+
+const DEFAULT_INIT: RequestInit = {
+  credentials: "include",
+  headers: {
+    Accept: "application/json",
+    "Content-Type": "application/json",
+  },
+};
+
+function ensureTrailingSlash(value: string): string {
+  return value.endsWith("/") ? value : `${value}/`;
+}
+
+function isAbsoluteUrl(value: string): boolean {
+  return /^[a-zA-Z][a-zA-Z\d+\-.]*:/.test(value);
+}
+
+function mergeHeaders(base?: HeadersInit, override?: HeadersInit): Headers {
+  const headers = new Headers(base);
+  if (!override) {
+    return headers;
+  }
+
+  const overrideHeaders = new Headers(override);
+  overrideHeaders.forEach((value, key) => {
+    headers.set(key, value);
+  });
+
+  return headers;
+}
+
+function mergeRequestInit(init?: RequestInit): RequestInit {
+  const mergedHeaders = mergeHeaders(
+    DEFAULT_INIT.headers,
+    init?.headers,
+  );
+
+  return {
+    ...DEFAULT_INIT,
+    ...init,
+    headers: mergedHeaders,
+  };
+}
+
+export function getApiBaseUrl(): string {
+  return process.env.NEXT_PUBLIC_API_BASE_URL?.trim() || DEFAULT_API_BASE_URL;
+}
+
+function resolveRelativePath(url: URL, base: string): string {
+  if (!base.startsWith("/")) {
+    return url.toString();
+  }
+
+  return `${url.pathname}${url.search}${url.hash}`;
+}
+
+export function resolveRequestInfo(
+  input: RequestInfo,
+  baseUrl = getApiBaseUrl(),
+): RequestInfo {
+  if (typeof input !== "string") {
+    return input;
+  }
+
+  if (isAbsoluteUrl(input) || input.startsWith("//")) {
+    return input;
+  }
+
+  const normalizedBaseUrl = baseUrl || DEFAULT_API_BASE_URL;
+
+  if (isAbsoluteUrl(normalizedBaseUrl) || normalizedBaseUrl.startsWith("//")) {
+    const absoluteBase = ensureTrailingSlash(normalizedBaseUrl);
+    const normalizedInput = input.replace(/^\//, "");
+    return new URL(normalizedInput, absoluteBase).toString();
+  }
+
+  const dummyOrigin = "http://localhost";
+  const baseWithOrigin = new URL(
+    ensureTrailingSlash(normalizedBaseUrl),
+    dummyOrigin,
+  );
+
+  const normalizedInput = input.startsWith("/")
+    ? input.replace(/^\/+/, "")
+    : input;
+
+  const resolved = new URL(normalizedInput, baseWithOrigin);
+
+  return resolveRelativePath(resolved, normalizedBaseUrl);
+}
+
 export class FetchError extends Error {
   constructor(
     public status: number,
@@ -12,13 +104,16 @@ export async function fetcher<T>(
   input: RequestInfo,
   init?: RequestInit,
 ): Promise<T> {
-  const res = await fetch(input, init);
-  if (!res.ok) {
+  const resolvedInput = resolveRequestInfo(input);
+  const response = await fetch(resolvedInput, mergeRequestInit(init));
+
+  if (!response.ok) {
     const error = new FetchError(
-      res.status,
-      `Failed to fetch data: ${res.status} ${res.statusText}`,
+      response.status,
+      `Failed to fetch data: ${response.status} ${response.statusText}`,
     );
     throw error;
   }
-  return res.json() as Promise<T>;
+
+  return response.json() as Promise<T>;
 }

--- a/lib/hooks/useData.ts
+++ b/lib/hooks/useData.ts
@@ -1,7 +1,7 @@
 import useSWR, { SWRConfiguration } from "swr";
 import { fetcher, FetchError } from "../fetcher";
 
-export type ApiEndpoint = "/api/stats" | "/api/users" | (string & {});
+export type ApiEndpoint = "stats" | "users" | (string & {});
 
 export type FetchState<T> = {
   data: T | undefined;

--- a/mocks/__tests__/browser.test.ts
+++ b/mocks/__tests__/browser.test.ts
@@ -1,0 +1,38 @@
+import { TextDecoder, TextEncoder } from "util";
+
+if (!globalThis.TextEncoder) {
+  // @ts-expect-error TextEncoder is available in browsers but must be polyfilled for Node tests
+  globalThis.TextEncoder = TextEncoder;
+}
+
+if (!globalThis.TextDecoder) {
+  // @ts-expect-error TextDecoder is available in browsers but must be polyfilled for Node tests
+  globalThis.TextDecoder = TextDecoder;
+}
+
+jest.mock("msw/browser", () => ({
+  setupWorker: jest.fn(() => ({
+    start: jest.fn(),
+  })),
+}));
+jest.mock("../handlers", () => ({
+  handlers: [],
+}));
+
+import { DEFAULT_API_BASE_URL } from "@/lib/fetcher";
+import { shouldBypassWorker } from "../browser";
+
+describe("MockServiceWorker bootstrap", () => {
+  it("starts when using the default relative base url", () => {
+    expect(shouldBypassWorker(DEFAULT_API_BASE_URL)).toBe(false);
+    expect(shouldBypassWorker(`${DEFAULT_API_BASE_URL}/`)).toBe(false);
+  });
+
+  it("skips when using a custom relative path", () => {
+    expect(shouldBypassWorker("/api/v1")).toBe(true);
+  });
+
+  it("skips when using an absolute base url", () => {
+    expect(shouldBypassWorker("https://example.com/api")).toBe(true);
+  });
+});

--- a/mocks/browser.ts
+++ b/mocks/browser.ts
@@ -1,10 +1,42 @@
 import { setupWorker } from "msw/browser";
+import { DEFAULT_API_BASE_URL, getApiBaseUrl } from "@/lib/fetcher";
 import { handlers } from "./handlers";
 
 export const worker = setupWorker(...handlers);
 
+function normalizeBaseUrl(value: string) {
+  if (!value) {
+    return value;
+  }
+
+  if (value === "/") {
+    return value;
+  }
+
+  return value.replace(/\/+$/, "");
+}
+
+function isAbsoluteUrl(value: string) {
+  return /^[a-zA-Z][a-zA-Z\d+\-.]*:/.test(value) || value.startsWith("//");
+}
+
+export function shouldBypassWorker(baseUrl: string) {
+  if (isAbsoluteUrl(baseUrl)) {
+    return true;
+  }
+
+  return (
+    normalizeBaseUrl(baseUrl || DEFAULT_API_BASE_URL) !==
+    normalizeBaseUrl(DEFAULT_API_BASE_URL)
+  );
+}
+
 export async function startBrowserWorker() {
   if (typeof window === "undefined") {
+    return;
+  }
+
+  if (shouldBypassWorker(getApiBaseUrl())) {
     return;
   }
 


### PR DESCRIPTION
## Summary
- add base URL resolution helpers and default RequestInit merging to the shared fetcher
- adjust data hooks/pages to use relative API keys and document the NEXT_PUBLIC_API_BASE_URL behaviour
- gate the MSW browser worker behind the resolved base URL and add coverage for the new bypass rules

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68d593ece364832aa7dac309cdd53f44