### PR TITLE
Enhance fetcher error handling

### DIFF
--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -19,6 +19,7 @@ export default function DashboardPage() {
     data: stats,
     isLoading: isLoadingStats,
     isError: isStatsError,
+    error: statsError,
     mutate: mutateStats,
   } = useData<DashboardStats>("stats");
 
@@ -26,6 +27,7 @@ export default function DashboardPage() {
     data: users,
     isLoading: isLoadingUsers,
     isError: isUsersError,
+    error: usersError,
     mutate: mutateUsers,
   } = useData<User[]>("users");
 
@@ -37,6 +39,7 @@ export default function DashboardPage() {
     return (
       <ErrorState
         message={t("dashboard.errors.stats", "Failed to load dashboard data")}
+        error={statsError}
         retry={() => mutateStats()}
       />
     );
@@ -46,6 +49,7 @@ export default function DashboardPage() {
     return (
       <ErrorState
         message={t("dashboard.errors.users", "Failed to load user data")}
+        error={usersError}
         retry={() => mutateUsers()}
       />
     );

--- a/components/common/ErrorState.tsx
+++ b/components/common/ErrorState.tsx
@@ -1,16 +1,41 @@
 "use client";
 import { XCircleIcon } from "@heroicons/react/20/solid";
+import { FetchError } from "@/lib/fetcher";
 import { useLocale } from "@/contexts/LocaleProvider";
 
 type Props = {
   message?: string;
   retry?: () => void;
+  error?: Error | FetchError;
 };
 
-export default function ErrorState({ message, retry }: Props) {
+function resolveErrorDetails(error?: Error | FetchError): string | undefined {
+  if (!error) {
+    return undefined;
+  }
+
+  if (error instanceof FetchError) {
+    const { details } = error;
+
+    if (details && typeof details === "object" && "message" in details) {
+      const detailMessage = (details as Record<string, unknown>).message;
+      return typeof detailMessage === "string" ? detailMessage : undefined;
+    }
+
+    if (typeof details === "string") {
+      return details;
+    }
+  }
+
+  return undefined;
+}
+
+export default function ErrorState({ message, retry, error }: Props) {
   const { t } = useLocale();
   const resolvedMessage =
     message ?? t("common.errors.generic", "Something went wrong");
+  const detailMessage = resolveErrorDetails(error);
+
   return (
     <div className="rounded-lg border border-red-100 bg-red-50 p-4 dark:border-red-900 dark:bg-red-950">
       <div className="flex items-start">
@@ -19,6 +44,11 @@ export default function ErrorState({ message, retry }: Props) {
           <p className="text-sm text-red-600 dark:text-red-500">
             {resolvedMessage}
           </p>
+          {detailMessage && (
+            <p className="mt-1 text-sm text-red-600 dark:text-red-400">
+              {detailMessage}
+            </p>
+          )}
           {retry && (
             <button
               onClick={retry}

--- a/lib/__tests__/fetcher.test.ts
+++ b/lib/__tests__/fetcher.test.ts
@@ -24,10 +24,22 @@ describe("fetcher", () => {
   });
 
   it("throws for error responses", async () => {
+    const clone = jest
+      .fn()
+      .mockReturnValueOnce({
+        json: jest.fn().mockRejectedValue(new Error("Invalid JSON")),
+        text: jest.fn(),
+      })
+      .mockReturnValueOnce({
+        json: jest.fn(),
+        text: jest.fn().mockResolvedValue(""),
+      });
+
     global.fetch = jest.fn().mockResolvedValue({
       ok: false,
       status: 500,
       statusText: "Internal Server Error",
+      clone,
     } as any);
 
     await expect(fetcher("stats")).rejects.toThrow(
@@ -35,14 +47,59 @@ describe("fetcher", () => {
     );
   });
 
-  it("exposes FetchError metadata when request fails", async () => {
+  it("attaches parsed json error details", async () => {
+    const details = { message: "Too many requests" };
+    const clone = jest.fn().mockReturnValue({
+      json: jest.fn().mockResolvedValue(details),
+      text: jest.fn(),
+    });
+
+    const response = {
+      ok: false,
+      status: 429,
+      statusText: "Too Many Requests",
+      clone,
+    } as any;
+
+    global.fetch = jest.fn().mockResolvedValue(response);
+
+    expect.assertions(6);
+
+    try {
+      await fetcher("stats");
+    } catch (error) {
+      expect(error).toBeInstanceOf(FetchError);
+      expect((error as FetchError).status).toBe(429);
+      expect(error).toHaveProperty(
+        "message",
+        "Failed to fetch data: 429 Too Many Requests",
+      );
+      expect((error as FetchError).details).toEqual(details);
+      expect((error as FetchError).response).toBe(response);
+      expect(clone).toHaveBeenCalledTimes(1);
+    }
+  });
+
+  it("falls back to text details when json parsing fails", async () => {
+    const clone = jest
+      .fn()
+      .mockReturnValueOnce({
+        json: jest.fn().mockRejectedValue(new Error("Invalid JSON")),
+        text: jest.fn(),
+      })
+      .mockReturnValueOnce({
+        json: jest.fn(),
+        text: jest.fn().mockResolvedValue("Plain error message"),
+      });
+
     global.fetch = jest.fn().mockResolvedValue({
       ok: false,
       status: 400,
       statusText: "Bad Request",
+      clone,
     } as any);
 
-    expect.assertions(4);
+    expect.assertions(5);
 
     try {
       await fetcher("stats");
@@ -53,7 +110,8 @@ describe("fetcher", () => {
         "message",
         "Failed to fetch data: 400 Bad Request",
       );
-      expect((error as FetchError).name).toBe("FetchError");
+      expect((error as FetchError).details).toBe("Plain error message");
+      expect(clone).toHaveBeenCalledTimes(2);
     }
   });
 

--- a/lib/fetcher.ts
+++ b/lib/fetcher.ts
@@ -94,6 +94,8 @@ export class FetchError extends Error {
   constructor(
     public status: number,
     message: string,
+    public details?: unknown,
+    public response?: Response,
   ) {
     super(message);
     this.name = "FetchError";
@@ -108,9 +110,24 @@ export async function fetcher<T>(
   const response = await fetch(resolvedInput, mergeRequestInit(init));
 
   if (!response.ok) {
+    let details: unknown;
+
+    try {
+      details = await response.clone().json();
+    } catch {
+      try {
+        const text = await response.clone().text();
+        details = text || undefined;
+      } catch {
+        details = undefined;
+      }
+    }
+
     const error = new FetchError(
       response.status,
       `Failed to fetch data: ${response.status} ${response.statusText}`,
+      details,
+      response,
     );
     throw error;
   }


### PR DESCRIPTION
## Summary
- extend FetchError to carry optional response metadata and parsed error details
- parse failed responses for JSON or text payloads before throwing and cover both cases with tests
- surface richer error messaging in the dashboard error state component

## Testing
- npm test -- --runTestsByPath lib/__tests__/fetcher.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68d595f8d550832aab26a532ed752608