### PR TITLE
Update useData mutate typing

### DIFF
--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -40,7 +40,9 @@ export default function DashboardPage() {
       <ErrorState
         message={t("dashboard.errors.stats", "Failed to load dashboard data")}
         error={statsError}
-        retry={() => mutateStats()}
+        retry={() => {
+          void mutateStats();
+        }}
       />
     );
   }
@@ -50,7 +52,9 @@ export default function DashboardPage() {
       <ErrorState
         message={t("dashboard.errors.users", "Failed to load user data")}
         error={usersError}
-        retry={() => mutateUsers()}
+        retry={() => {
+          void mutateUsers();
+        }}
       />
     );
   }

--- a/lib/hooks/useData.ts
+++ b/lib/hooks/useData.ts
@@ -1,4 +1,4 @@
-import useSWR, { SWRConfiguration } from "swr";
+import useSWR, { KeyedMutator, SWRConfiguration } from "swr";
 import { fetcher, FetchError } from "../fetcher";
 
 export type ApiEndpoint = "stats" | "users" | (string & {});
@@ -10,7 +10,7 @@ export type FetchState<T> = {
   error: FetchError | undefined;
   isEmpty: boolean;
   isValidating: boolean;
-  mutate: () => void;
+  mutate: KeyedMutator<T>;
 };
 
 export function useData<T>(


### PR DESCRIPTION
## Summary
- import the KeyedMutator type from swr and expose it from useData so mutate keeps SWR's overloads
- wrap dashboard retry handlers to ignore mutate's Promise return value and preserve void-returning callbacks

## Testing
- npm run lint
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68d597873eb4832aad4e52a92aa23991