### PR TITLE
Add domain hooks for dashboard data access

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ styles/, tailwind.config.ts, eslint.config.mjs, jest.config.js
 
 - **Branding & theme**: Update design tokens in `app/globals.css` and Tailwind config; see [`docs/theming.md`](docs/theming.md).
 - **Navigation & layout**: Adjust shell components in `components/layout/*` (sidebar, header, breadcrumbs) and register new items via `constants/nav.ts`.
-- **Data & validation**: Modify schemas in `lib/validators`, swap SWR hooks for your data fetching layer, and update mocks under `mocks/data`.
+- **Data & validation**: Modify schemas in `lib/validators`, use the domain hooks in `lib/hooks` (for example `useUsers`, `useDashboardStats`) as your SWR entry point, and update mocks under `mocks/data`.
 - **UI primitives**: Extend the React components in `components/ui` or scaffold new ones following the same API surface.
 
 ## Guides

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -1,6 +1,5 @@
 "use client";
 import { DashboardStats, User } from "@/lib/types";
-import { useData } from "@/lib/hooks/useData";
 import EmptyState from "@/components/common/EmptyState";
 import ErrorState from "@/components/common/ErrorState";
 import DashboardSkeleton from "@/components/dashboard/DashboardSkeleton";
@@ -12,6 +11,8 @@ import PerformanceSnapshot from "@/components/dashboard/PerformanceSnapshot";
 import RecentUsersTable from "@/components/dashboard/RecentUsersTable";
 import RecentActivitySection from "@/components/dashboard/RecentActivitySection";
 import { useLocale } from "@/contexts/LocaleProvider";
+import { useDashboardStats } from "@/lib/hooks/useDashboardStats";
+import { useUsers } from "@/lib/hooks/useUsers";
 
 export default function DashboardPage() {
   const { t } = useLocale();
@@ -21,7 +22,7 @@ export default function DashboardPage() {
     isError: isStatsError,
     error: statsError,
     mutate: mutateStats,
-  } = useData<DashboardStats>("stats");
+  } = useDashboardStats();
 
   const {
     data: users,
@@ -29,7 +30,7 @@ export default function DashboardPage() {
     isError: isUsersError,
     error: usersError,
     mutate: mutateUsers,
-  } = useData<User[]>("users");
+  } = useUsers();
 
   if (isLoadingStats || isLoadingUsers) {
     return <DashboardSkeleton />;

--- a/app/users/page.tsx
+++ b/app/users/page.tsx
@@ -1,6 +1,4 @@
 "use client";
-import useSWR from "swr";
-import { fetcher } from "@/lib/fetcher";
 import DataTable from "@/components/data-table/DataTable";
 import type { ColumnDef } from "@tanstack/react-table";
 import { User } from "@/lib/types";
@@ -11,9 +9,10 @@ import EmptyState from "@/components/common/EmptyState";
 import PageLayout from "@/components/layout/PageLayout";
 import { TableSkeleton } from "@/components/loading/Skeletons";
 import { useLocale } from "@/contexts/LocaleProvider";
+import { useUsers } from "@/lib/hooks/useUsers";
 
 export default function UsersPage() {
-  const { data, mutate, isLoading, error } = useSWR<User[]>("users", fetcher);
+  const { data, mutate, isLoading, error } = useUsers();
   const [deleteId, setDeleteId] = useState<string | null>(null);
   const { t } = useLocale();
 

--- a/docs/creating-pages.md
+++ b/docs/creating-pages.md
@@ -90,7 +90,7 @@ Re-use the building blocks that are already styled:
 
 For asynchronous data, start with the shared utilities:
 
-- [`lib/hooks/useData`](../lib/hooks/useData.ts) wraps SWR and returns `{ data, isLoading, isError, isEmpty, mutate }` for consistent loading states.
+- Domain hooks like [`lib/hooks/useUsers`](../lib/hooks/useUsers.ts) or [`lib/hooks/useDashboardStats`](../lib/hooks/useDashboardStats.ts) wrap [`useData`](../lib/hooks/useData.ts) so every page shares the same loading state contract. Create a new wrapper when you add an endpoint.
 - [`app/api`](../app/api) contains route handlers powered by the JSON fixtures in [`mocks/data`](../mocks/data). Clone an existing handler if you need quick mock endpoints.
 - [`lib/validators.ts`](../lib/validators.ts) provides Zod schemas you can extend to keep forms and APIs in sync.
 

--- a/lib/hooks/useDashboardStats.ts
+++ b/lib/hooks/useDashboardStats.ts
@@ -1,0 +1,6 @@
+import { DashboardStats } from "../types";
+import { useData, UseDataConfig } from "./useData";
+
+export function useDashboardStats(config?: UseDataConfig<DashboardStats>) {
+  return useData<DashboardStats>("stats", config);
+}

--- a/lib/hooks/useData.ts
+++ b/lib/hooks/useData.ts
@@ -13,9 +13,11 @@ export type FetchState<T> = {
   mutate: KeyedMutator<T>;
 };
 
+export type UseDataConfig<T> = SWRConfiguration<T, FetchError>;
+
 export function useData<T>(
   url: ApiEndpoint | null,
-  config?: SWRConfiguration,
+  config?: UseDataConfig<T>,
 ): FetchState<T> {
   const { data, error, isLoading, isValidating, mutate } = useSWR<T>(
     url,

--- a/lib/hooks/useUsers.ts
+++ b/lib/hooks/useUsers.ts
@@ -1,0 +1,6 @@
+import { User } from "../types";
+import { useData, UseDataConfig } from "./useData";
+
+export function useUsers(config?: UseDataConfig<User[]>) {
+  return useData<User[]>("users", config);
+}


### PR DESCRIPTION
## Summary
- add a typed `UseDataConfig` helper and domain-specific wrappers for users and dashboard stats
- refactor dashboard and users pages to consume the new hooks
- document the canonical hooks path for data fetching in the README and creating-pages guide

## Testing
- npm run lint
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68d598bfc628832a89f33a05b6ea3c81