### PR TITLE
Default to static locale for export

### DIFF
--- a/app/api/auth/route.ts
+++ b/app/api/auth/route.ts
@@ -1,5 +1,7 @@
 import { NextResponse } from "next/server";
 
+export const dynamic = "force-static";
+
 export async function POST(req: Request) {
   const body = await req.json();
   return NextResponse.json({ ok: true, user: { id: "1", ...body } });

--- a/app/api/stats/route.ts
+++ b/app/api/stats/route.ts
@@ -1,6 +1,8 @@
 import { NextResponse } from "next/server";
 import data from "@/mocks/data/stats.json";
 
+export const dynamic = "force-static";
+
 export async function GET() {
   return NextResponse.json(data);
 }

--- a/app/api/users/route.ts
+++ b/app/api/users/route.ts
@@ -1,6 +1,8 @@
 import { NextResponse } from "next/server";
 import data from "@/mocks/data/users.json";
 
+export const dynamic = "force-static";
+
 export async function GET() {
   return NextResponse.json(data);
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,7 +1,6 @@
 import "./globals.css";
 import type { ReactNode } from "react";
 import type { Metadata } from "next";
-import { cookies, headers } from "next/headers";
 import Sidebar from "@/components/layout/Sidebar";
 import Header from "@/components/layout/Header";
 import { ThemeProvider } from "@/contexts/ThemeProvider";
@@ -12,38 +11,11 @@ import MockServiceWorker from "@/components/common/MockServiceWorker";
 import {
   DEFAULT_LOCALE,
   getDictionary,
-  isLocale,
   translate,
   type Locale,
 } from "@/lib/i18n";
 
-const LOCALE_COOKIE = "locale";
-
-const resolveRequestLocale = async (): Promise<Locale> => {
-  const cookieStore = await cookies();
-  const cookieLocale = cookieStore.get(LOCALE_COOKIE)?.value;
-  if (isLocale(cookieLocale)) {
-    return cookieLocale;
-  }
-
-  const headersList = await headers();
-  const acceptLanguage = headersList.get("accept-language");
-  if (acceptLanguage) {
-    const requestedLocales = acceptLanguage
-      .split(",")
-      .map((token) => token.trim().split(";")[0]?.toLowerCase())
-      .filter(Boolean) as string[];
-
-    for (const locale of requestedLocales) {
-      const base = locale.split("-")[0];
-      if (isLocale(base)) {
-        return base;
-      }
-    }
-  }
-
-  return DEFAULT_LOCALE;
-};
+const resolveRequestLocale = async (): Promise<Locale> => DEFAULT_LOCALE;
 
 export async function generateMetadata(): Promise<Metadata> {
   const locale = await resolveRequestLocale();

--- a/app/users/page.tsx
+++ b/app/users/page.tsx
@@ -3,7 +3,7 @@ import DataTable from "@/components/data-table/DataTable";
 import type { ColumnDef } from "@tanstack/react-table";
 import { User } from "@/lib/types";
 import { Button } from "@/components/ui/Button";
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import ConfirmModal from "@/components/common/ConfirmModal";
 import EmptyState from "@/components/common/EmptyState";
 import PageLayout from "@/components/layout/PageLayout";
@@ -16,42 +16,47 @@ export default function UsersPage() {
   const [deleteId, setDeleteId] = useState<string | null>(null);
   const { t } = useLocale();
 
-  const columns: ColumnDef<User>[] = [
-    { header: t("users.table.columns.name", "Name"), accessorKey: "name" },
-    { header: t("users.table.columns.email", "Email"), accessorKey: "email" },
-    { header: t("users.table.columns.role", "Role"), accessorKey: "role" },
-    {
-      header: t("users.table.columns.active", "Active"),
-      accessorKey: "active",
-      cell: ({ row }) =>
-        row.original.active
-          ? t("users.table.active.yes", "Yes")
-          : t("users.table.active.no", "No"),
-    },
-    {
-      header: t("users.table.columns.actions", "Actions"),
-      cell: ({ row }) => (
-        <div className="flex gap-2">
-          <Button
-            type="button"
-            onClick={() =>
-              alert(`${t("common.buttons.edit", "Edit")} ${row.original.id}`)
-            }
-            className="px-2 py-1"
-          >
-            {t("common.buttons.edit", "Edit")}
-          </Button>
-          <Button
-            type="button"
-            onClick={() => setDeleteId(row.original.id)}
-            className="bg-red-600 px-2 py-1"
-          >
-            {t("common.buttons.delete", "Delete")}
-          </Button>
-        </div>
-      ),
-    },
-  ];
+  const columns: ColumnDef<User>[] = useMemo(
+    () => [
+      { header: t("users.table.columns.name", "Name"), accessorKey: "name" },
+      { header: t("users.table.columns.email", "Email"), accessorKey: "email" },
+      { header: t("users.table.columns.role", "Role"), accessorKey: "role" },
+      {
+        header: t("users.table.columns.active", "Active"),
+        accessorKey: "active",
+        cell: ({ row }) =>
+          row.original.active
+            ? t("users.table.active.yes", "Yes")
+            : t("users.table.active.no", "No"),
+      },
+      {
+        header: t("users.table.columns.actions", "Actions"),
+        cell: ({ row }) => (
+          <div className="flex gap-2">
+            <Button
+              type="button"
+              onClick={() =>
+                alert(`${t("common.buttons.edit", "Edit")} ${row.original.id}`)
+              }
+              className="px-2 py-1"
+            >
+              {t("common.buttons.edit", "Edit")}
+            </Button>
+            <Button
+              type="button"
+              onClick={() => setDeleteId(row.original.id)}
+              className="bg-red-600 px-2 py-1"
+            >
+              {t("common.buttons.delete", "Delete")}
+            </Button>
+          </div>
+        ),
+      },
+    ],
+    [t],
+  );
+
+  const tableData = useMemo(() => data ?? [], [data]);
 
   const handleDelete = () => {
     if (data && deleteId) {
@@ -102,7 +107,6 @@ export default function UsersPage() {
   }
 
   const hasUsers = (data?.length ?? 0) > 0;
-  const tableData = data ?? [];
 
   return (
     <>


### PR DESCRIPTION
## Summary
- remove server request locale detection so the root layout no longer uses cookies/headers APIs during static export
- keep metadata and providers using the default locale so GitHub Pages exports can prerender the blank page and other routes

## Testing
- npm run lint
- CI=1 npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d5a0a7fa54832a98a1da3e12531a70