### PR TITLE
Refactor dashboard page data fetching

### DIFF
--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -1,95 +1,37 @@
-"use client";
-import { DashboardStats, User } from "@/lib/types";
-import EmptyState from "@/components/common/EmptyState";
-import ErrorState from "@/components/common/ErrorState";
-import DashboardSkeleton from "@/components/dashboard/DashboardSkeleton";
-import PageLayout from "@/components/layout/PageLayout";
-import StatsGrid from "@/components/dashboard/StatsGrid";
-import RevenueSection from "@/components/dashboard/RevenueSection";
-import SegmentsList from "@/components/dashboard/SegmentsList";
-import PerformanceSnapshot from "@/components/dashboard/PerformanceSnapshot";
-import RecentUsersTable from "@/components/dashboard/RecentUsersTable";
-import RecentActivitySection from "@/components/dashboard/RecentActivitySection";
-import { useLocale } from "@/contexts/LocaleProvider";
-import { useDashboardStats } from "@/lib/hooks/useDashboardStats";
-import { useUsers } from "@/lib/hooks/useUsers";
+import DashboardPageClient from "@/components/dashboard/DashboardPageClient";
+import { fetcher } from "@/lib/fetcher";
+import { DEFAULT_LOCALE, isLocale, type Locale } from "@/lib/i18n";
+import type { DashboardStats, User } from "@/lib/types";
+import { cookies } from "next/headers";
 
-export default function DashboardPage() {
-  const { t } = useLocale();
-  const {
-    data: stats,
-    isLoading: isLoadingStats,
-    isError: isStatsError,
-    error: statsError,
-    mutate: mutateStats,
-  } = useDashboardStats();
+async function getDashboardData() {
+  const [initialStats, initialUsers] = await Promise.all([
+    fetcher<DashboardStats>("stats"),
+    fetcher<User[]>("users"),
+  ]);
 
-  const {
-    data: users,
-    isLoading: isLoadingUsers,
-    isError: isUsersError,
-    error: usersError,
-    mutate: mutateUsers,
-  } = useUsers();
+  return { initialStats, initialUsers };
+}
 
-  if (isLoadingStats || isLoadingUsers) {
-    return <DashboardSkeleton />;
+function getRequestLocale(): Locale {
+  const localeCookie = cookies().get("locale")?.value;
+
+  if (localeCookie && isLocale(localeCookie)) {
+    return localeCookie;
   }
 
-  if (isStatsError) {
-    return (
-      <ErrorState
-        message={t("dashboard.errors.stats", "Failed to load dashboard data")}
-        error={statsError}
-        retry={() => {
-          void mutateStats();
-        }}
-      />
-    );
-  }
+  return DEFAULT_LOCALE;
+}
 
-  if (isUsersError) {
-    return (
-      <ErrorState
-        message={t("dashboard.errors.users", "Failed to load user data")}
-        error={usersError}
-        retry={() => {
-          void mutateUsers();
-        }}
-      />
-    );
-  }
-
-  if (!stats) {
-    return (
-      <EmptyState
-        message={t("common.empty.dashboard", "No dashboard data available")}
-      />
-    );
-  }
+export default async function DashboardPage() {
+  const locale = getRequestLocale();
+  const { initialStats, initialUsers } = await getDashboardData();
 
   return (
-    <PageLayout
-      title={t("dashboard.page.title", "Dashboard Overview")}
-      description={t(
-        "dashboard.page.description",
-        "Welcome back! Here's a summary of your business metrics.",
-      )}
-    >
-      <StatsGrid stats={stats} />
-
-      <div className="grid-container lg:grid-cols-2">
-        <RevenueSection
-          trend={stats.series}
-          revenueByRegion={stats.revenueByRegion}
-        />
-        <SegmentsList segments={stats.usersByType} />
-        <PerformanceSnapshot metrics={stats.performanceMetrics} />
-      </div>
-
-      <RecentUsersTable users={users} />
-
-      <RecentActivitySection activity={stats.recentActivity} />
-    </PageLayout>
+    <DashboardPageClient
+      initialLocale={locale}
+      initialStats={initialStats}
+      initialUsers={initialUsers}
+    />
   );
 }

--- a/components/dashboard/DashboardPageClient.tsx
+++ b/components/dashboard/DashboardPageClient.tsx
@@ -1,0 +1,113 @@
+"use client";
+
+import { useEffect } from "react";
+import type { DashboardStats, User } from "@/lib/types";
+import EmptyState from "@/components/common/EmptyState";
+import ErrorState from "@/components/common/ErrorState";
+import DashboardSkeleton from "@/components/dashboard/DashboardSkeleton";
+import PageLayout from "@/components/layout/PageLayout";
+import StatsGrid from "@/components/dashboard/StatsGrid";
+import RevenueSection from "@/components/dashboard/RevenueSection";
+import SegmentsList from "@/components/dashboard/SegmentsList";
+import PerformanceSnapshot from "@/components/dashboard/PerformanceSnapshot";
+import RecentUsersTable from "@/components/dashboard/RecentUsersTable";
+import RecentActivitySection from "@/components/dashboard/RecentActivitySection";
+import { useLocale } from "@/contexts/LocaleProvider";
+import { useDashboardStats } from "@/lib/hooks/useDashboardStats";
+import { useUsers } from "@/lib/hooks/useUsers";
+import type { Locale } from "@/lib/i18n";
+
+interface DashboardPageClientProps {
+  initialLocale: Locale;
+  initialStats: DashboardStats;
+  initialUsers: User[];
+}
+
+export default function DashboardPageClient({
+  initialLocale,
+  initialStats,
+  initialUsers,
+}: DashboardPageClientProps) {
+  const { t, setLocale } = useLocale();
+
+  useEffect(() => {
+    setLocale(initialLocale);
+  }, [initialLocale, setLocale]);
+
+  const {
+    data: stats,
+    isLoading: isLoadingStats,
+    isError: isStatsError,
+    error: statsError,
+    mutate: mutateStats,
+  } = useDashboardStats({ fallbackData: initialStats });
+
+  const {
+    data: users,
+    isLoading: isLoadingUsers,
+    isError: isUsersError,
+    error: usersError,
+    mutate: mutateUsers,
+  } = useUsers({ fallbackData: initialUsers });
+
+  if (isLoadingStats || isLoadingUsers) {
+    return <DashboardSkeleton />;
+  }
+
+  if (isStatsError) {
+    return (
+      <ErrorState
+        message={t("dashboard.errors.stats", "Failed to load dashboard data")}
+        error={statsError}
+        retry={() => {
+          void mutateStats();
+        }}
+      />
+    );
+  }
+
+  if (isUsersError) {
+    return (
+      <ErrorState
+        message={t("dashboard.errors.users", "Failed to load user data")}
+        error={usersError}
+        retry={() => {
+          void mutateUsers();
+        }}
+      />
+    );
+  }
+
+  if (!stats) {
+    return (
+      <EmptyState
+        message={t("common.empty.dashboard", "No dashboard data available")}
+      />
+    );
+  }
+
+  return (
+    <PageLayout
+      title={t("dashboard.page.title", "Dashboard Overview")}
+      description={t(
+        "dashboard.page.description",
+        "Welcome back! Here's a summary of your business metrics.",
+      )}
+    >
+      <StatsGrid stats={stats} />
+
+      <div className="grid-container lg:grid-cols-2">
+        <RevenueSection
+          trend={stats.series}
+          revenueByRegion={stats.revenueByRegion}
+        />
+        <SegmentsList segments={stats.usersByType} />
+        <PerformanceSnapshot metrics={stats.performanceMetrics} />
+      </div>
+
+      <RecentUsersTable users={users} />
+
+      <RecentActivitySection activity={stats.recentActivity} />
+    </PageLayout>
+  );
+}


### PR DESCRIPTION
## Summary
- move dashboard client UI into a dedicated `DashboardPageClient` component
- fetch dashboard stats and users on the server and pass locale and initial data to the client
- hydrate client hooks with fallback data while preserving revalidation

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d934fcf438832ab7a76bd42372a431