### PR TITLE
Lazy load chart components with skeleton placeholders

### DIFF
--- a/components/charts/dynamic.tsx
+++ b/components/charts/dynamic.tsx
@@ -1,0 +1,34 @@
+import dynamic from "next/dynamic";
+import { Skeleton } from "@/components/ui/Skeleton";
+
+type LineChartComponent = (typeof import("./LineChart"))["default"];
+type BarChartComponent = (typeof import("./BarChart"))["default"];
+type DoughnutChartComponent = (typeof import("./DoughnutChart"))["default"];
+
+function ChartSkeleton() {
+  return <Skeleton className="h-64 w-full" />;
+}
+
+export const LineChart = dynamic<LineChartComponent>(
+  () => import("./LineChart"),
+  {
+    ssr: false,
+    loading: ChartSkeleton,
+  },
+);
+
+export const BarChart = dynamic<BarChartComponent>(
+  () => import("./BarChart"),
+  {
+    ssr: false,
+    loading: ChartSkeleton,
+  },
+);
+
+export const DoughnutChart = dynamic<DoughnutChartComponent>(
+  () => import("./DoughnutChart"),
+  {
+    ssr: false,
+    loading: ChartSkeleton,
+  },
+);

--- a/components/dashboard/RevenueSection.tsx
+++ b/components/dashboard/RevenueSection.tsx
@@ -1,6 +1,5 @@
 "use client";
-import LineChart from "@/components/charts/LineChart";
-import BarChart from "@/components/charts/BarChart";
+import { BarChart, LineChart } from "@/components/charts/dynamic";
 import EmptyState from "@/components/common/EmptyState";
 import { DashboardStats } from "@/lib/types";
 import { useLocale } from "@/contexts/LocaleProvider";


### PR DESCRIPTION
## Summary
- add a dynamic charts module that lazy-loads chart implementations with a skeleton placeholder
- update the revenue section to consume the lazy chart components

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d9365c1058832a85f3c75dc1ed10d6