### PR TITLE
feat: lazily load user tables

### DIFF
--- a/app/users/page.tsx
+++ b/app/users/page.tsx
@@ -1,5 +1,5 @@
 "use client";
-import DataTable from "@/components/data-table/DataTable";
+import dynamic from "next/dynamic";
 import type { ColumnDef } from "@tanstack/react-table";
 import { User } from "@/lib/types";
 import { Button } from "@/components/ui/Button";
@@ -10,6 +10,17 @@ import PageLayout from "@/components/layout/PageLayout";
 import { TableSkeleton } from "@/components/loading/Skeletons";
 import { useLocale } from "@/contexts/LocaleProvider";
 import { useUsers } from "@/lib/hooks/useUsers";
+import type { DataTableProps } from "@/components/data-table/DataTable";
+
+const USERS_TABLE_COLUMNS = 5;
+
+const DataTable = dynamic<DataTableProps<User>>(
+  () => import("@/components/data-table/DataTable"),
+  {
+    ssr: false,
+    loading: () => <TableSkeleton columns={USERS_TABLE_COLUMNS} rows={6} />,
+  },
+);
 
 export default function UsersPage() {
   const { data, mutate, isLoading, error } = useUsers();

--- a/components/dashboard/RecentUsersTable.tsx
+++ b/components/dashboard/RecentUsersTable.tsx
@@ -1,10 +1,20 @@
 "use client";
 import { useMemo } from "react";
-import DataTable from "@/components/data-table/DataTable";
+import dynamic from "next/dynamic";
+import type { DataTableProps } from "@/components/data-table/DataTable";
 import EmptyState from "@/components/common/EmptyState";
 import { getRecentUsersColumns } from "@/components/dashboard/columns";
 import { User } from "@/lib/types";
 import { useLocale } from "@/contexts/LocaleProvider";
+import { TableSkeleton } from "@/components/loading/Skeletons";
+
+const DataTable = dynamic<DataTableProps<User>>(
+  () => import("@/components/data-table/DataTable"),
+  {
+    ssr: false,
+    loading: () => <TableSkeleton columns={3} rows={5} />,
+  },
+);
 
 type RecentUsersTableProps = {
   users?: User[];

--- a/components/data-table/DataTable.tsx
+++ b/components/data-table/DataTable.tsx
@@ -7,7 +7,7 @@ import DataTableBody from "./DataTableBody";
 import { useConfiguredTable } from "./useConfiguredTable";
 import { useLocale } from "@/contexts/LocaleProvider";
 
-type DataTableProps<TData> = {
+export type DataTableProps<TData> = {
   columns: ColumnDef<TData, any>[];
   data: TData[];
   searchKey?: string;


### PR DESCRIPTION
## Summary
- dynamically import the shared DataTable on the users page and dashboard widget
- show a TableSkeleton fallback while the table bundle is loading
- export the DataTableProps type so ColumnDef usage stays type-safe with lazy loading

## Testing
- npm test -- --runTestsByPath components/data-table/__tests__/DataTable.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68d9389776a8832ab7fda786400f14fc