### PR TITLE
Fix dashboard locale detection and update docs for lazy loading

### DIFF
--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -13,8 +13,9 @@ async function getDashboardData() {
   return { initialStats, initialUsers };
 }
 
-function getRequestLocale(): Locale {
-  const localeCookie = cookies().get("locale")?.value;
+async function getRequestLocale(): Promise<Locale> {
+  const cookieStore = await cookies();
+  const localeCookie = cookieStore.get("locale")?.value;
 
   if (localeCookie && isLocale(localeCookie)) {
     return localeCookie;
@@ -24,7 +25,7 @@ function getRequestLocale(): Locale {
 }
 
 export default async function DashboardPage() {
-  const locale = getRequestLocale();
+  const locale = await getRequestLocale();
   const { initialStats, initialUsers } = await getDashboardData();
 
   return (

--- a/docs/components.md
+++ b/docs/components.md
@@ -8,7 +8,7 @@ This guide explains how the reusable pieces of the dashboard fit together and wh
 - [`components/ui`](../components/ui): low-level inputs and buttons that expose native HTML props with Tailwind styling.
 - [`components/data-table`](../components/data-table): TanStack Table wrappers used on the Users screen.
 - [`components/forms`](../components/forms): form sections composed around `react-hook-form` registries.
-- [`components/dashboard`](../components/dashboard) and [`components/examples`](../components/examples): pre-built cards, charts, and composite blocks used for demos.
+- [`components/dashboard`](../components/dashboard) and [`components/examples`](../components/examples): pre-built cards, charts, and composite blocks used for demos. Dashboard-specific wrappers often split heavy widgets into client and server layers to keep the initial payload small.
 - [`components/feedback`](../components/feedback): notification helpers (`ToasterProvider`) wired to Sonner.
 
 ## Layout primitives
@@ -82,11 +82,26 @@ These components forward refs and native HTML attributes, making them drop-in re
 
 Each file exports a single component—inspect the source if you need additional variants or to adapt them to a design system.
 
+## Chart wrappers
+
+The chart implementations under [`components/charts`](../components/charts) are designed to load lazily because they depend on
+`chart.js`, which is a large client-side bundle. Always import from [`components/charts/dynamic.tsx`](../components/charts/dynamic.tsx)
+inside client components so Next.js can skip SSR and hydrate them only when necessary:
+
+```tsx
+import { LineChart, BarChart } from "@/components/charts/dynamic";
+
+<LineChart data={series} label={t("dashboard.revenue.datasetLabel")!} />
+```
+
+Each dynamic wrapper renders a `<Skeleton />` placeholder until the browser downloads the real chart code, preventing `chart.js`
+from inflating the server-rendered HTML or delaying TTFB.
+
 ## Data table toolkit
 
 The Users page relies on a small toolkit around TanStack Table located in [`components/data-table`](../components/data-table).
 
-- **`DataTable`** wraps the entire experience: pagination, search, column visibility, and localized summary text. Configure it with `columns`, `data`, and optional `searchKey` / `searchKeys` for global filtering.
+- **`DataTable`** wraps the entire experience: pagination, search, column visibility, and localized summary text. Configure it with `columns`, `data`, and optional `searchKey` / `searchKeys` for global filtering. Import it through `next/dynamic` (see [`RecentUsersTable`](../components/dashboard/RecentUsersTable.tsx) or [`app/users/page.tsx`](../app/users/page.tsx)) to disable SSR and reuse the `TableSkeleton` placeholder while the bundle loads.
 - **`useConfiguredTable`** centralizes table state (sorting, filtering, pagination) and wires localization placeholders. Import it directly if you need custom rendering with the same behavior.
 - **`DataTableToolbar`** combines the search input and column visibility menu. Pass it a `table` instance, the current `filter` string, and the `onFilterChange` handler returned by `useConfiguredTable`.
 - **`DataTableBody`** renders the table element, header groups, empty state, and row cells.

--- a/docs/creating-pages.md
+++ b/docs/creating-pages.md
@@ -6,11 +6,13 @@ Use this checklist whenever you add a route inside the admin dashboard. It mirro
 
 1. Duplicate `app/blank/page.tsx` into `app/<your-route>/page.tsx` and adjust the slug.
 2. Replace the placeholder copy in the new file while keeping the `PageLayout` wrapper.
-3. Add a navigation item in `constants/nav.ts` for the new page.
-4. Provide translations for the navigation label and page copy in every file under `locales/`.
-5. Drop in UI blocks from `components/` or the examples under `app/examples/`.
-6. Connect data through hooks in `lib/hooks/` or by creating route handlers under `app/api/`.
-7. Verify the page renders, navigation is updated, and localization works in each language.
+3. Decide whether the page can stay a server component. If it only needs to fetch data, remove the `"use client"` directive and
+   pass the results into a client wrapper (see the Dashboard route for an example).
+4. Add a navigation item in `constants/nav.ts` for the new page.
+5. Provide translations for the navigation label and page copy in every file under `locales/`.
+6. Drop in UI blocks from `components/` or the examples under `app/examples/`.
+7. Connect data through hooks in `lib/hooks/` or by creating route handlers under `app/api/`.
+8. Verify the page renders, navigation is updated, and localization works in each language.
 
 ## 1. Create the route file
 
@@ -44,6 +46,8 @@ export default function ReportsPage() {
   );
 }
 ```
+
+> ℹ️ If the page only needs to fetch data and render static UI, drop the `"use client"` directive and fetch inside the server component instead. Pass the results to a smaller client wrapper when you need interactivity or SWR hooks. The Dashboard route (`app/dashboard/page.tsx` + `components/dashboard/DashboardPageClient.tsx`) showcases this split and keeps the initial payload lean.
 
 ## 2. Register the page in the sidebar
 


### PR DESCRIPTION
## Summary
- await the cookies helper when resolving the dashboard locale to avoid type errors in the server component
- document how the chart wrappers and data table should be loaded dynamically to keep bundles lean
- expand the page creation guide with guidance on splitting server and client components when fetching data

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d933e328d0832a8a8e79b3993716d2