### PR TITLE
Add skip link for main content

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -71,6 +71,27 @@
       "calt" 1;
   }
 
+  .skip-link {
+    position: absolute;
+    left: 1rem;
+    top: 1rem;
+    padding: 0.5rem 1rem;
+    border-radius: 0.5rem;
+    background-color: hsl(var(--primary));
+    color: hsl(var(--primary-foreground));
+    font-weight: 600;
+    transform: translateY(-200%);
+    transition: transform 150ms ease, opacity 150ms ease;
+    opacity: 0;
+    z-index: 50;
+  }
+
+  .skip-link:focus,
+  .skip-link:focus-visible {
+    transform: translateY(0);
+    opacity: 1;
+  }
+
   input[type="number"]::-webkit-inner-spin-button,
   input[type="number"]::-webkit-outer-spin-button {
     -webkit-appearance: none;

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -42,6 +42,9 @@ export default async function RootLayout({
   return (
     <html lang={locale} suppressHydrationWarning>
       <body className="min-h-screen bg-background font-sans antialiased">
+        <a className="skip-link" href="#main-content">
+          Skip to content
+        </a>
         <MockServiceWorker />
         <SpeedInsights />
         <ThemeProvider>
@@ -52,7 +55,10 @@ export default async function RootLayout({
                 <Sidebar />
                 <div className="flex flex-1 flex-col">
                   <Header />
-                  <main className="flex-1 px-4 py-6 sm:px-6 lg:px-8">
+                  <main
+                    id="main-content"
+                    className="flex-1 px-4 py-6 sm:px-6 lg:px-8"
+                  >
                     {children}
                   </main>
                 </div>


### PR DESCRIPTION
## Summary
- add a focusable skip link before the main content in the root layout
- assign an identifier to the main element and style the skip link for focus visibility

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d949d7f3c8832aa8bf3265410d5f0c