### PR TITLE
Add aria-current attribute to active sidebar links

### DIFF
--- a/components/layout/Sidebar.tsx
+++ b/components/layout/Sidebar.tsx
@@ -68,6 +68,7 @@ export default function Sidebar() {
                       key={item.key}
                       href={item.href ?? "#"}
                       className={`nav-item ${isActive(item.href) ? "nav-item-active" : ""}`}
+                      aria-current={isActive(item.href) ? "page" : undefined}
                       onClick={() => isOpen && close()}
                     >
                       <ItemIcon className="mr-2 h-4 w-4" />


### PR DESCRIPTION
## Summary
- add an aria-current attribute to sidebar navigation links when they are active to improve accessibility cues

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d94d0f6b58832abdcb33e880424829