### PR TITLE
Fix dashboard static build by avoiding request APIs

### DIFF
--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -1,100 +1,21 @@
 import DashboardPageClient from "@/components/dashboard/DashboardPageClient";
-import { fetcher, resolveRequestInfo } from "@/lib/fetcher";
-import { DEFAULT_LOCALE, isLocale, type Locale } from "@/lib/i18n";
+import { fetcher } from "@/lib/fetcher";
 import type { DashboardStats, User } from "@/lib/types";
-import { cookies, headers } from "next/headers";
-
-async function getServerRequestOrigin(): Promise<string> {
-  if (typeof window !== "undefined") {
-    return window.location.origin;
-  }
-
-  let host: string | null = null;
-  let protocol: string | null = null;
-
-  try {
-    const incomingHeaders = await headers();
-    host =
-      incomingHeaders.get("x-forwarded-host") ??
-      incomingHeaders.get("host");
-    protocol =
-      incomingHeaders.get("x-forwarded-proto") ??
-      incomingHeaders.get("x-forwarded-protocol");
-  } catch {
-    // `headers()` throws during static rendering when no request context exists.
-  }
-
-  const fallbackProtocol =
-    protocol ?? (process.env.NODE_ENV === "production" ? "https" : "http");
-
-  if (host) {
-    return `${fallbackProtocol}://${host}`;
-  }
-
-  const envUrl =
-    process.env.NEXT_PUBLIC_SITE_URL ??
-    process.env.NEXT_PUBLIC_APP_URL ??
-    process.env.VERCEL_URL ??
-    null;
-
-  if (envUrl) {
-    return envUrl.startsWith("http")
-      ? envUrl
-      : `${fallbackProtocol}://${envUrl.replace(/^\/+/, "")}`;
-  }
-
-  const port = process.env.PORT ?? "3000";
-
-  return `${fallbackProtocol}://127.0.0.1:${port}`;
-}
-
-function createServerRequestInfo(endpoint: string, origin: string): RequestInfo {
-  const resolved = resolveRequestInfo(endpoint);
-
-  if (typeof resolved !== "string") {
-    return resolved;
-  }
-
-  const isAbsoluteUrl =
-    /^[a-zA-Z][a-zA-Z\d+\-.]*:/.test(resolved) || resolved.startsWith("//");
-
-  if (isAbsoluteUrl) {
-    return resolved;
-  }
-
-  const pathname = resolved.startsWith("/") ? resolved : `/${resolved}`;
-
-  return new URL(pathname, origin).toString();
-}
 
 async function getDashboardData() {
-  const origin = await getServerRequestOrigin();
   const [initialStats, initialUsers] = await Promise.all([
-    fetcher<DashboardStats>(createServerRequestInfo("stats", origin)),
-    fetcher<User[]>(createServerRequestInfo("users", origin)),
+    fetcher<DashboardStats>("stats"),
+    fetcher<User[]>("users"),
   ]);
 
   return { initialStats, initialUsers };
 }
 
-async function getRequestLocale(): Promise<Locale> {
-  const cookieStore = await cookies();
-  const localeCookie = cookieStore.get("locale")?.value;
-
-  if (localeCookie && isLocale(localeCookie)) {
-    return localeCookie;
-  }
-
-  return DEFAULT_LOCALE;
-}
-
 export default async function DashboardPage() {
-  const locale = await getRequestLocale();
   const { initialStats, initialUsers } = await getDashboardData();
 
   return (
     <DashboardPageClient
-      initialLocale={locale}
       initialStats={initialStats}
       initialUsers={initialUsers}
     />

--- a/app/globals.css
+++ b/app/globals.css
@@ -114,6 +114,12 @@
     @apply mx-auto w-full max-w-7xl px-4 py-6;
   }
 
+  @media (max-width: 40rem) {
+    .page-container {
+      @apply px-4 py-5;
+    }
+  }
+
   @screen sm {
     .page-container {
       @apply px-6;
@@ -130,6 +136,12 @@
     @apply mb-6 rounded-lg bg-card p-4 shadow-sm transition-all duration-200 hover:shadow-md;
   }
 
+  @media (max-width: 40rem) {
+    .section-container {
+      @apply p-4;
+    }
+  }
+
   @screen sm {
     .section-container {
       @apply p-6;
@@ -138,6 +150,12 @@
 
   .grid-container {
     @apply grid gap-6;
+  }
+
+  @media (max-width: 40rem) {
+    .grid-container {
+      @apply gap-4;
+    }
   }
 
   .table-container {
@@ -160,6 +178,24 @@
     @apply scroll-m-20 pb-2 text-3xl font-semibold tracking-tight transition-colors first:mt-0;
   }
 
+  @media (max-width: 40rem) {
+    .heading-1 {
+      @apply text-3xl;
+    }
+
+    .heading-2 {
+      @apply text-2xl;
+    }
+
+    .heading-3 {
+      @apply text-xl;
+    }
+
+    .heading-4 {
+      @apply text-lg;
+    }
+  }
+
   .heading-3 {
     @apply scroll-m-20 text-2xl font-semibold tracking-tight;
   }
@@ -170,6 +206,16 @@
 
   .form-group {
     @apply space-y-2;
+  }
+
+  .form-section {
+    @apply rounded-lg bg-card p-4 shadow-sm transition-colors duration-200;
+  }
+
+  @screen sm {
+    .form-section {
+      @apply p-6;
+    }
   }
 
   .form-label {

--- a/app/users/page.tsx
+++ b/app/users/page.tsx
@@ -1,5 +1,4 @@
 "use client";
-import dynamic from "next/dynamic";
 import type { ColumnDef } from "@tanstack/react-table";
 import { User } from "@/lib/types";
 import { Button } from "@/components/ui/Button";
@@ -10,22 +9,15 @@ import PageLayout from "@/components/layout/PageLayout";
 import { TableSkeleton } from "@/components/loading/Skeletons";
 import { useLocale } from "@/contexts/LocaleProvider";
 import { useUsers } from "@/lib/hooks/useUsers";
-import type { DataTableProps } from "@/components/data-table/DataTable";
+import { useClientDataTable } from "@/components/data-table/useClientDataTable";
 
 const USERS_TABLE_COLUMNS = 5;
-
-const DataTable = dynamic<DataTableProps<User>>(
-  () => import("@/components/data-table/DataTable"),
-  {
-    ssr: false,
-    loading: () => <TableSkeleton columns={USERS_TABLE_COLUMNS} rows={6} />,
-  },
-);
 
 export default function UsersPage() {
   const { data, mutate, isLoading, error } = useUsers();
   const [deleteId, setDeleteId] = useState<string | null>(null);
   const { t } = useLocale();
+  const DataTable = useClientDataTable<User>();
 
   const columns: ColumnDef<User>[] = useMemo(
     () => [
@@ -130,12 +122,16 @@ export default function UsersPage() {
       >
         <div className="section-container">
           {hasUsers ? (
-            <DataTable
-              columns={columns}
-              data={tableData}
-              searchKeys={["name", "email"]}
-              initialPageSize={10}
-            />
+            DataTable ? (
+              <DataTable
+                columns={columns}
+                data={tableData}
+                searchKeys={["name", "email"]}
+                initialPageSize={10}
+              />
+            ) : (
+              <TableSkeleton columns={USERS_TABLE_COLUMNS} rows={6} />
+            )
           ) : (
             <EmptyState
               title={t("common.messages.usersEmptyTitle", "No users yet")}

--- a/components/dashboard/DashboardPageClient.tsx
+++ b/components/dashboard/DashboardPageClient.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { useEffect } from "react";
 import type { DashboardStats, User } from "@/lib/types";
 import EmptyState from "@/components/common/EmptyState";
 import ErrorState from "@/components/common/ErrorState";
@@ -15,24 +14,17 @@ import RecentActivitySection from "@/components/dashboard/RecentActivitySection"
 import { useLocale } from "@/contexts/LocaleProvider";
 import { useDashboardStats } from "@/lib/hooks/useDashboardStats";
 import { useUsers } from "@/lib/hooks/useUsers";
-import type { Locale } from "@/lib/i18n";
 
 interface DashboardPageClientProps {
-  initialLocale: Locale;
   initialStats: DashboardStats;
   initialUsers: User[];
 }
 
 export default function DashboardPageClient({
-  initialLocale,
   initialStats,
   initialUsers,
 }: DashboardPageClientProps) {
-  const { t, setLocale } = useLocale();
-
-  useEffect(() => {
-    setLocale(initialLocale);
-  }, [initialLocale, setLocale]);
+  const { t } = useLocale();
 
   const {
     data: stats,

--- a/components/dashboard/RecentActivityFeed.tsx
+++ b/components/dashboard/RecentActivityFeed.tsx
@@ -42,14 +42,14 @@ export default function RecentActivityFeed({
           item.typeLabel ??
           item.type.toUpperCase();
         return (
-          <li key={item.id} className="flex items-start gap-3">
+          <li key={item.id} className="flex flex-col gap-2 sm:flex-row sm:items-start sm:gap-3">
             <span
               className={`mt-1 rounded-full px-2 py-1 text-xs font-semibold ${badgeClass}`}
             >
               {typeLabel}
             </span>
             <div className="flex-1">
-              <div className="flex items-center justify-between gap-2">
+              <div className="flex flex-col gap-1 sm:flex-row sm:items-center sm:justify-between sm:gap-2">
                 <p className="text-sm font-medium text-foreground">
                   {localizedTitle}
                 </p>

--- a/components/dashboard/RecentUsersTable.tsx
+++ b/components/dashboard/RecentUsersTable.tsx
@@ -1,20 +1,11 @@
 "use client";
 import { useMemo } from "react";
-import dynamic from "next/dynamic";
-import type { DataTableProps } from "@/components/data-table/DataTable";
 import EmptyState from "@/components/common/EmptyState";
 import { getRecentUsersColumns } from "@/components/dashboard/columns";
 import { User } from "@/lib/types";
 import { useLocale } from "@/contexts/LocaleProvider";
 import { TableSkeleton } from "@/components/loading/Skeletons";
-
-const DataTable = dynamic<DataTableProps<User>>(
-  () => import("@/components/data-table/DataTable"),
-  {
-    ssr: false,
-    loading: () => <TableSkeleton columns={3} rows={5} />,
-  },
-);
+import { useClientDataTable } from "@/components/data-table/useClientDataTable";
 
 type RecentUsersTableProps = {
   users?: User[];
@@ -29,10 +20,11 @@ export default function RecentUsersTable({
   const tableData = hasUsers ? (users ?? []).slice(0, 5) : [];
   const { t } = useLocale();
   const columns = useMemo(() => getRecentUsersColumns(t), [t]);
+  const DataTable = useClientDataTable<User>();
 
   return (
     <div className="section-container">
-      <div className="mb-6 flex items-center justify-between">
+      <div className="mb-6 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
         <h3 className="heading-4">
           {t("dashboard.recentUsers.title", "Recent Users")}
         </h3>
@@ -42,12 +34,16 @@ export default function RecentUsersTable({
       </div>
       <div className="table-container">
         {hasUsers ? (
-          <DataTable
-            columns={columns}
-            data={tableData}
-            searchKeys={["name", "email"]}
-            initialPageSize={5}
-          />
+          DataTable ? (
+            <DataTable
+              columns={columns}
+              data={tableData}
+              searchKeys={["name", "email"]}
+              initialPageSize={5}
+            />
+          ) : (
+            <TableSkeleton columns={3} rows={5} />
+          )
         ) : (
           <EmptyState message={t("common.empty.users", "No users found")} />
         )}

--- a/components/dashboard/SegmentsList.tsx
+++ b/components/dashboard/SegmentsList.tsx
@@ -24,7 +24,7 @@ export default function SegmentsList({ segments }: SegmentsListProps) {
           {segments.map((segment) => (
             <div
               key={segment.label}
-              className="flex items-center justify-between rounded-md bg-muted/40 px-4 py-3"
+              className="flex flex-col gap-3 rounded-md bg-muted/40 px-4 py-3 sm:flex-row sm:items-center sm:justify-between"
             >
               <div>
                 <p className="text-sm font-medium text-muted-foreground">

--- a/components/data-table/useClientDataTable.ts
+++ b/components/data-table/useClientDataTable.ts
@@ -1,0 +1,25 @@
+"use client";
+
+import { ComponentType, useEffect, useState } from "react";
+import type { DataTableProps } from "./DataTable";
+
+export function useClientDataTable<TData>() {
+  const [DataTableComponent, setDataTableComponent] =
+    useState<ComponentType<DataTableProps<TData>> | null>(null);
+
+  useEffect(() => {
+    let mounted = true;
+
+    void import("./DataTable").then((module) => {
+      if (mounted) {
+        setDataTableComponent(() => module.default);
+      }
+    });
+
+    return () => {
+      mounted = false;
+    };
+  }, []);
+
+  return DataTableComponent;
+}

--- a/components/forms/AddressSection.tsx
+++ b/components/forms/AddressSection.tsx
@@ -19,7 +19,7 @@ export default function AddressSection({
 }: AddressSectionProps) {
   const { t } = useLocale();
   return (
-    <div className="rounded-lg bg-white p-6 shadow dark:bg-gray-800">
+    <div className="form-section">
       <h2 className="mb-4 text-lg font-semibold">
         {t("forms.sections.address", "Address")}
       </h2>

--- a/components/forms/AgreementSection.tsx
+++ b/components/forms/AgreementSection.tsx
@@ -17,8 +17,8 @@ export default function AgreementSection({
 }: AgreementSectionProps) {
   const { t } = useLocale();
   return (
-    <div className="rounded-lg bg-white p-6 shadow dark:bg-gray-800">
-      <div className="mb-4 flex items-center gap-2">
+    <div className="form-section space-y-4">
+      <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
         <Checkbox {...register("agreement")} />
         <label className="text-sm">
           {t(
@@ -28,7 +28,7 @@ export default function AgreementSection({
         </label>
       </div>
       {errors.agreement && (
-        <p className="mb-4 text-sm text-red-600">{errors.agreement.message}</p>
+        <p className="text-sm text-red-600">{errors.agreement.message}</p>
       )}
 
       <Button type="submit" className="w-full">

--- a/components/forms/BasicInfoSection.tsx
+++ b/components/forms/BasicInfoSection.tsx
@@ -30,7 +30,7 @@ export default function BasicInfoSection({
   });
 
   return (
-    <div className="rounded-lg bg-white p-6 shadow dark:bg-gray-800">
+    <div className="form-section">
       <h2 className="mb-4 text-lg font-semibold">
         {t("forms.sections.basicInfo", "Basic Information")}
       </h2>

--- a/components/forms/NotificationsSection.tsx
+++ b/components/forms/NotificationsSection.tsx
@@ -14,26 +14,26 @@ export default function NotificationsSection({
 }: NotificationsSectionProps) {
   const { t } = useLocale();
   return (
-    <div className="rounded-lg bg-white p-6 shadow dark:bg-gray-800">
+    <div className="form-section">
       <h2 className="mb-4 text-lg font-semibold">
         {t("forms.sections.notifications", "Notification Preferences")}
       </h2>
       <div className="space-y-4">
-        <div className="flex items-center justify-between">
+        <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
           <label className="text-sm font-medium">
             {t("forms.fields.notifications.email", "Email Notifications")}
           </label>
           <Switch {...register("notifications.email")} />
         </div>
 
-        <div className="flex items-center justify-between">
+        <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
           <label className="text-sm font-medium">
             {t("forms.fields.notifications.sms", "SMS Notifications")}
           </label>
           <Switch {...register("notifications.sms")} />
         </div>
 
-        <div className="flex items-center justify-between">
+        <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
           <label className="text-sm font-medium">
             {t("forms.fields.notifications.push", "Push Notifications")}
           </label>

--- a/components/forms/RoleStatusSection.tsx
+++ b/components/forms/RoleStatusSection.tsx
@@ -17,7 +17,7 @@ export default function RoleStatusSection({
 }: RoleStatusSectionProps) {
   const { t } = useLocale();
   return (
-    <div className="rounded-lg bg-white p-6 shadow dark:bg-gray-800">
+    <div className="form-section">
       <h2 className="mb-4 text-lg font-semibold">
         {t("forms.sections.roleStatus", "Role and Status")}
       </h2>

--- a/components/forms/SkillsSelector.tsx
+++ b/components/forms/SkillsSelector.tsx
@@ -20,7 +20,7 @@ export default function SkillsSelector({
 }: SkillsSelectorProps) {
   const { t } = useLocale();
   return (
-    <div className="rounded-lg bg-white p-6 shadow dark:bg-gray-800">
+    <div className="form-section">
       <h2 className="mb-4 text-lg font-semibold">
         {t("forms.sections.skills", "Skills")}
       </h2>
@@ -31,10 +31,10 @@ export default function SkillsSelector({
             return (
               <label
                 key={skill}
-                className={`cursor-pointer rounded-full px-3 py-1 text-sm ${
+                className={`cursor-pointer rounded-full px-3 py-1 text-sm transition-colors focus-within:outline-none focus-within:ring-2 focus-within:ring-ring focus-within:ring-offset-2 ${
                   active
-                    ? "bg-blue-600 text-white"
-                    : "bg-gray-100 text-gray-700 dark:bg-gray-700 dark:text-gray-300"
+                    ? "bg-primary text-primary-foreground"
+                    : "bg-muted text-muted-foreground hover:bg-muted/80"
                 }`}
               >
                 <input

--- a/components/layout/Breadcrumbs.tsx
+++ b/components/layout/Breadcrumbs.tsx
@@ -17,7 +17,7 @@ export default function Breadcrumbs({ className = "" }: BreadcrumbsProps) {
       className={`text-sm text-muted-foreground ${className}`}
       aria-label="Breadcrumb"
     >
-      <ol className="flex items-center gap-1">
+      <ol className="flex flex-wrap items-center gap-x-1 gap-y-2">
         <li>
           <Link
             href="/dashboard"

--- a/components/layout/Header.tsx
+++ b/components/layout/Header.tsx
@@ -41,7 +41,7 @@ export default function Header() {
   const { t } = useLocale();
   return (
     <header className="sticky top-0 z-40 w-full border-b bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60">
-      <div className="mx-auto flex h-14 w-full max-w-7xl items-center justify-between px-4 sm:px-6 lg:px-8">
+      <div className="mx-auto flex w-full max-w-7xl flex-wrap items-center justify-between gap-3 px-4 py-2 sm:flex-nowrap sm:gap-0 sm:px-6 sm:py-0 lg:px-8 min-h-[3.5rem]">
         <div className="flex items-center gap-3">
           <button
             className="inline-flex items-center justify-center rounded-md p-2 hover:bg-accent hover:text-accent-foreground md:hidden"
@@ -54,7 +54,7 @@ export default function Header() {
             {t("header.title", "Admin Dashboard")}
           </span>
         </div>
-        <div className="flex items-center gap-3">
+        <div className="flex flex-1 flex-wrap items-center justify-end gap-2 sm:flex-none sm:flex-nowrap sm:gap-3">
           <LocaleSwitcher />
           <button
             onClick={toggleTheme}

--- a/docs/components.md
+++ b/docs/components.md
@@ -101,7 +101,8 @@ from inflating the server-rendered HTML or delaying TTFB.
 
 The Users page relies on a small toolkit around TanStack Table located in [`components/data-table`](../components/data-table).
 
-- **`DataTable`** wraps the entire experience: pagination, search, column visibility, and localized summary text. Configure it with `columns`, `data`, and optional `searchKey` / `searchKeys` for global filtering. Import it through `next/dynamic` (see [`RecentUsersTable`](../components/dashboard/RecentUsersTable.tsx) or [`app/users/page.tsx`](../app/users/page.tsx)) to disable SSR and reuse the `TableSkeleton` placeholder while the bundle loads.
+- **`DataTable`** wraps the entire experience: pagination, search, column visibility, and localized summary text. Configure it with `columns`, `data`, and optional `searchKey` / `searchKeys` for global filtering. Pair it with `useClientDataTable` (see [`RecentUsersTable`](../components/dashboard/RecentUsersTable.tsx) or [`app/users/page.tsx`](../app/users/page.tsx)) to lazy-load the bundle on the client while reusing the `TableSkeleton` placeholder.
+- **`useClientDataTable`** loads the client-only table implementation inside a `useEffect`, preventing React from warning about state updates before mount and ensuring the skeleton renders until the table bundle is ready.
 - **`useConfiguredTable`** centralizes table state (sorting, filtering, pagination) and wires localization placeholders. Import it directly if you need custom rendering with the same behavior.
 - **`DataTableToolbar`** combines the search input and column visibility menu. Pass it a `table` instance, the current `filter` string, and the `onFilterChange` handler returned by `useConfiguredTable`.
 - **`DataTableBody`** renders the table element, header groups, empty state, and row cells.


### PR DESCRIPTION
## Summary
- fetch dashboard seed data with relative API paths so the page can prerender without access to request headers or cookies
- simplify the dashboard client component to rely on the current locale context instead of forcing a server-derived locale on mount

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d9485e1ccc832a8e335c19b65ca25e