### PR TITLE
Fix mobile overflow and add extra breakpoint

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -66,6 +66,7 @@
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
     @apply bg-background text-foreground;
+    overflow-x: hidden;
     font-feature-settings:
       "rlig" 1,
       "calt" 1;
@@ -120,6 +121,12 @@
     }
   }
 
+  @screen xs {
+    .page-container {
+      @apply px-3;
+    }
+  }
+
   @screen sm {
     .page-container {
       @apply px-6;
@@ -142,6 +149,12 @@
     }
   }
 
+  @screen xs {
+    .section-container {
+      @apply p-3;
+    }
+  }
+
   @screen sm {
     .section-container {
       @apply p-6;
@@ -155,6 +168,12 @@
   @media (max-width: 40rem) {
     .grid-container {
       @apply gap-4;
+    }
+  }
+
+  @screen xs {
+    .grid-container {
+      @apply gap-3;
     }
   }
 

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -57,7 +57,7 @@ export default async function RootLayout({
                   <Header />
                   <main
                     id="main-content"
-                    className="flex-1 px-4 py-6 sm:px-6 lg:px-8"
+                    className="flex-1 px-4 py-6 xs:px-3 sm:px-6 lg:px-8"
                   >
                     {children}
                   </main>

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -20,6 +20,9 @@ const config: Config = {
       },
     },
     extend: {
+      screens: {
+        xs: { max: "375px" },
+      },
       borderColor: {
         border: "hsl(var(--border))",
       },


### PR DESCRIPTION
## Summary
- hide horizontal overflow on mobile to eliminate unintended scrolling
- introduce an xs (≤375px) breakpoint and tighten spacing for narrow devices
- adjust main content padding to use the new breakpoint

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d95bf2a4e0832abc736c71546cee04